### PR TITLE
Make the issue regex less obnoxious

### DIFF
--- a/app/issues.py
+++ b/app/issues.py
@@ -7,7 +7,7 @@ from discord import Message
 from app import config
 from app.github import g
 
-ISSUE_REGEX = re.compile(r"#(\d{2,})(?!\.\d+)\b")
+ISSUE_REGEX = re.compile(r"#(\d{2,})(?!\.\d)\b")
 ISSUE_TEMPLATE = "**{kind} #{issue.number}:** {issue.title}\n{issue.html_url}\n"
 
 


### PR DESCRIPTION
No one's going to ever be referring to #1 through #9 since they were fixed forever ago (mid 2022), and #2.5 doesn't exist.
Also https://discord.com/channels/1005603569187160125/1005603569711452192/1269583726359089235 and https://discord.com/channels/1005603569187160125/1185082566869532763/1269601212009943061.

In case anyone who doesn't speak regex sees this, try [toss it through RegExr](https://regexr.com/84am5).