### PR TITLE
feat: add an interaction for blacklist checking

### DIFF
--- a/app/features/vouches.py
+++ b/app/features/vouches.py
@@ -15,6 +15,35 @@ from app.utils import is_dm, is_mod, is_tester, server_only_warning
 COOLDOWN_TIME = 604_800  # 1 week
 
 
+@bot.tree.context_menu(name="Check vouch blacklist")
+@discord.app_commands.default_permissions(manage_messages=True)
+async def check_blacklist(
+    interaction: discord.Interaction, member: discord.User
+) -> None:
+    if is_dm(interaction.user):
+        await server_only_warning(interaction)
+        return
+
+    db_user = fetch_user(member)
+
+    await interaction.response.send_message(
+        f"{member.mention} is "
+        + ("not " * (not db_user.is_vouch_blacklisted))
+        + "blacklisted from vouching.",
+        ephemeral=True,
+    )
+
+
+@bot.tree.command(
+    name="check-blacklist", description="Check if a user is blacklisted from vouching."
+)
+@discord.app_commands.default_permissions(manage_messages=True)
+async def check_blacklist_command(
+    interaction: discord.Interaction, member: discord.User
+) -> None:
+    await check_blacklist.callback(interaction, member)
+
+
 @bot.tree.context_menu(name="Blacklist from vouching")
 @discord.app_commands.default_permissions(manage_messages=True)
 async def blacklist_vouch_member(


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/8a5f6a61-e649-492e-a6a8-eadb50ecdd7c" width="50%">

(currently we have to toggle twice)
also turns out the main blacklist feature had strings saying it's blacklisting the vouchee rather than the voucher