### PR TITLE
fix: correct multiline subtext handling for message moving

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -77,8 +77,7 @@ async def move_message_via_webhook(
         subtext += f" Moved from {message.channel.mention} by {executor.mention}"
     if skipped:
         subtext += f" (skipped {skipped} large attachment(s))"
-    if subtext:
-        content += f"\n-#{subtext}"
+    content += "".join(f"\n-# {line.lstrip()}" for line in subtext.splitlines())
 
     # We have validated ahead of time that this is a discord.Member
     # So we can safely access server-specific attributes


### PR DESCRIPTION
before
<img src="https://github.com/user-attachments/assets/07cc152b-2827-453d-84e7-f0e7b013b407" width="50%">

after
<img src="https://github.com/user-attachments/assets/63ae2431-a212-484b-9bab-bb8fd02256c8" width="50%">
