### PR TITLE
feat: implement discussion mentions

### DIFF
--- a/app/features/issues.py
+++ b/app/features/issues.py
@@ -21,7 +21,7 @@ query getDiscussion($number: Int!, $org: String!, $repo: String!) {
     }
   }
 }
-""".strip()
+"""
 
 
 async def handle_issues(message: Message) -> None:


### PR DESCRIPTION
apparently fetching discussions requires a GraphQL query...
using `types.SimpleNamespace` in `get_discussions` so `ISSUE_TEMPLATE` can still be used