### PR TITLE
fix: correctly handle too long entity numbers

### DIFF
--- a/app/features/entity_mentions.py
+++ b/app/features/entity_mentions.py
@@ -10,7 +10,7 @@ from app.utils import is_dm, is_tester, try_dm
 
 REPO_URL = "https://github.com/ghostty-org/ghostty/"
 ENTITY_REGEX = re.compile(
-    rf"({REPO_URL}(?:issues|pull|discussions)/|#)(\d{{,6}})(?!\.\d)\b"
+    rf"({REPO_URL}(?:issues|pull|discussions)/|#)(\d{{1,6}})(?!\.\d)\b"
 )
 ENTITY_TEMPLATE = "**{kind} #{entity.number}:** {entity.title}\n"
 


### PR DESCRIPTION
Fixes #47.

Apparently `{,n}` with a word boundary has funny behavior I wasn't aware of:
```py
>>> import re
>>> p = re.compile(r"#\d{,3}\b")
>>> p.match("#")
>>> p.match("#1")
<re.Match object; span=(0, 2), match='#1'>
>>> p.match("#12")
<re.Match object; span=(0, 3), match='#12'>
>>> p.match("#123")
<re.Match object; span=(0, 4), match='#123'>
>>> p.match("#1234")
<re.Match object; span=(0, 1), match='#'>  # I was expecting no match here 😄
```