### PR TITLE
feat: ignore pending members from `/beta-waitlist`

### DIFF
--- a/app/features/beta_waitlist.py
+++ b/app/features/beta_waitlist.py
@@ -22,7 +22,7 @@ async def beta_waitlist(interaction: discord.Interaction, n: int) -> None:
         (
             member
             for member in interaction.guild.members
-            if not (member.bot or is_tester(member))
+            if not (member.bot or member.pending or is_tester(member))
         ),
         # Apparently joined_at can be None "in certain cases" :)
         key=lambda m: cast(dt.datetime, m.joined_at),


### PR DESCRIPTION
Closes #56

`.pending` = hasn't agreed to server rules