### PR TITLE
fix: allow delete-button msg update to silently fail

### DIFF
--- a/app/features/entity_mentions.py
+++ b/app/features/entity_mentions.py
@@ -111,7 +111,7 @@ async def handle_entities(message: Message) -> None:
         view=DeleteMention(message, len(entities)),
     )
     await asyncio.sleep(30)
-    with suppress(discord.NotFound):
+    with suppress(discord.NotFound, discord.HTTPException):
         await sent_message.edit(view=None)
 
 


### PR DESCRIPTION
Fixes #81