### PR TITLE
fix: correct discussion querying to use a less constrained method

### DIFF
--- a/app/components/entity_mentions.py
+++ b/app/components/entity_mentions.py
@@ -163,7 +163,7 @@ def get_discussion(repo: Repository, number: int) -> SimpleNamespace:
                 "org": config.GITHUB_ORG,
                 "repo": repo.name,
             },
-        }
+        },
     )
     if "errors" in response:
         raise KeyError((repo.name, number))


### PR DESCRIPTION
Fixes #95. Fixes #96. This should get discussions finally working 🎉

### Story time
When originally implementing this I was looking at `pygithub`'s docs to see if it exposed a public method to get a discussion. It did not, but after looking at its internals I found that it had a `Requester.graphql_query` method I could use (the Discussions endpoint is a GraphQL one, unlike PRs/issues which have a REST endpoint). Looking at its implementation, however, it turned out that it was wrapping the variables in another dict:
```py
class Requester:
    def graphql_query(self, query: str, variables: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
        input_ = {"query": query, "variables": {"input": variables}}
        # *snip*
```
So if I wanted to use the following data for my query (as per GitHub docs):
```py
{
    "number": 2354,
    "org": "ghostty-org",
    "repo": "ghostty",
}
```
the endpoint would actually receive this:
```py

{
    "input": {
        "number": 2354,
        "org": "ghostty-org",
        "repo": "ghostty",
    }
}
```
which made it error out.

As I played around with this I concluded that it could work if the internal method didn't wrap the variables:
```diff
-input_ = {"query": query, "variables": {"input": variables}}
+input_ = {"query": query, "variables": variables}
```
I believe at that point I stopped working on the feature with a thought "how can I work around this?" and went on to do something else.

When I came back to this and changed some more code I realized discussions suddenly started to work and just went on to finish up the details and deliver the PR (I guess I didn't play the "why does it work?" card). After this we went back and forth for 2 months with me trying to figure out why it doesn't work on Render, but works for me locally.

Today I asked @iceghost for a review of #89; he wanted to set up a bot to properly test my changes. He encountered some issues with dependencies (which made me suspect it could be a Nix problem, as I don't use Nix to develop the bot), but after some time he got it running and could reproduce the issue found on Sentry (#96). Then we went on to investigating if the dependency versions were matching as that was the main suspect at the time (this investigation also found why CI here has been failing the entire time). After finding that Nix had the same version of pygithub, I pointed out how my version of the `graphql_query` method look different.

And then I was hit with "so... you modified the source locally".

... :neutral_face:

This entire time I've been working in an environment that had a custom implementation of that method, which is why it only worked for me. Somewhat funny nobody else tried running the bot and noticing it in those 2 months 😄

I was finally able to reproduce the error after doing:
```sh
$ rm -r $(poetry env info -p)
$ poetry install
$ poetry run python -m app
```

---

This PR changes `get_discussion` to rely on a different querying method that doesn't wrap the dict (the same one `Requester.graphql_query` uses, actually).

HUGE thanks to iceghost for making me realize this. I feel so embarrassed 😓