### PR TITLE
Escape underscores in username when ghost-pinging

### DIFF
--- a/app/components/move_message.py
+++ b/app/components/move_message.py
@@ -77,8 +77,9 @@ class Ghostping(discord.ui.View):
     ) -> None:
         await interaction.response.defer(ephemeral=True)
         await (await self._channel.send(self._author.mention)).delete()
+        escaped_name = self._author.name.replace("_", "\\_")
         await interaction.followup.send(
-            f"Ghostpinged {self._author.name}.", ephemeral=True
+            f"Ghostpinged {escaped_name}.", ephemeral=True
         )
 
 

--- a/app/components/move_message.py
+++ b/app/components/move_message.py
@@ -78,9 +78,7 @@ class Ghostping(discord.ui.View):
         await interaction.response.defer(ephemeral=True)
         await (await self._channel.send(self._author.mention)).delete()
         escaped_name = self._author.name.replace("_", "\\_")
-        await interaction.followup.send(
-            f"Ghostpinged {escaped_name}.", ephemeral=True
-        )
+        await interaction.followup.send(f"Ghostpinged {escaped_name}.", ephemeral=True)
 
 
 class HelpPostTitle(discord.ui.Modal, title="Turn into #help post"):


### PR DESCRIPTION
A username like `_therealmitchellh_` would show up as italics, and something like `thereal_mitchellh_` would be even more confusing since only a part of it is in italics.