### PR TITLE
feat: improve `/docs` command

### DIFF
--- a/app/components/docs.py
+++ b/app/components/docs.py
@@ -86,7 +86,9 @@ async def page_autocomplete(
 @bot.tree.command(name="docs", description="Link a documentation page.")
 @autocomplete(section=section_autocomplete, page=page_autocomplete)
 @SERVER_ONLY
-async def docs(interaction: discord.Interaction, section: str, page: str) -> None:
+async def docs(
+    interaction: discord.Interaction, section: str, page: str, message: str = ""
+) -> None:
     if section not in SECTIONS:
         await interaction.response.send_message(
             f"Invalid section {section!r}", ephemeral=True
@@ -104,5 +106,5 @@ async def docs(interaction: discord.Interaction, section: str, page: str) -> Non
         section_path, page = "config/keybind/", "sequence"
 
     await interaction.response.send_message(
-        URL_TEMPLATE.format(section=section_path, page=page)
+        f"{message}\n{URL_TEMPLATE.format(section=section_path, page=page)}"
     )

--- a/app/components/docs.py
+++ b/app/components/docs.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import json
-from typing import cast
+from typing import NotRequired, TypedDict, cast
 
 import discord
 from discord.app_commands import Choice, autocomplete
@@ -13,10 +15,16 @@ URL_TEMPLATE = "https://ghostty.org/docs/{section}{page}"
 
 SECTIONS = {
     "action": "config/keybind/reference#",
+    "config": "config/",
     "help": "help/",
     "install": "install/",
-    "vt": "vt/",
+    "keybind": "config/keybind/",
     "option": "config/reference#",
+    "vt-concepts": "vt/concepts/",
+    "vt-control": "vt/control/",
+    "vt-csi": "vt/csi/",
+    "vt-esc": "vt/esc/",
+    "vt": "vt/",
 }
 
 WEBSITE_PATHS = {
@@ -26,16 +34,30 @@ WEBSITE_PATHS = {
 }
 
 
+class Entry(TypedDict):
+    type: str
+    path: str
+    title: str
+    children: NotRequired[list[Entry]]
+
+
+def _load_children(sitemap: dict[str, list[str]], path: str, children: list[Entry]) -> None:
+    sitemap[path] = []
+    for item in children:
+        sitemap[path].append((page := item["path"].lstrip("/")) or "overview")
+        if item["type"] == "folder":
+            _load_children(sitemap, f"{path}-{page}", item.get("children", []))
+
+
 def refresh_sitemap() -> None:
-    # Reading vt/, install/, help/ subpages by checking nav.json
+    # Reading vt/, install/, help/, config/,
+    # config/keybind/ subpages by reading nav.json
     raw = cast(ContentFile, REPOSITORIES["web"].get_contents(WEBSITE_PATHS["nav"]))
-    nav = json.loads(raw.decoded_content)["items"]
+    nav: list[Entry] = json.loads(raw.decoded_content)["items"]
     for entry in nav:
         if entry["type"] != "folder":
             continue
-        sitemap[entry["path"].strip("/")] = list(
-            filter(None, (item["path"].strip("/") for item in entry["children"]))
-        )
+        _load_children(sitemap, entry["path"].lstrip("/"), entry.get("children", []))
 
     # Reading config references by parsing headings in .mdx files
     for key, path in WEBSITE_PATHS.items():
@@ -47,8 +69,10 @@ def refresh_sitemap() -> None:
             for line in raw.decoded_content.splitlines()
             if line.startswith(b"## ")
         ]
-    # Special case for /config/keybind/sequence
-    sitemap["action"].append("trigger-sequences")
+
+    # Manual adjustments
+    sitemap["install"].remove("release-notes")
+    sitemap["keybind"] = sitemap.pop("config-keybind")
 
 
 sitemap: dict[str, list[str]] = {}
@@ -101,9 +125,7 @@ async def docs(
         return
 
     section_path = SECTIONS[section]
-    # Special case for /config/keybind/sequence
-    if (section, page) == ("action", "trigger-sequences"):
-        section_path, page = "config/keybind/", "sequence"
+    page = page if page != "overview" else ""
 
     await interaction.response.send_message(
         f"{message}\n{URL_TEMPLATE.format(section=section_path, page=page)}"

--- a/app/components/docs.py
+++ b/app/components/docs.py
@@ -75,6 +75,7 @@ def refresh_sitemap() -> None:
     # Manual adjustments
     sitemap["install"].remove("release-notes")
     sitemap["keybind"] = sitemap.pop("config-keybind")
+    del sitemap["install-release-notes"]
 
 
 sitemap: dict[str, list[str]] = {}

--- a/app/components/docs.py
+++ b/app/components/docs.py
@@ -76,6 +76,8 @@ def refresh_sitemap() -> None:
     sitemap["install"].remove("release-notes")
     sitemap["keybind"] = sitemap.pop("config-keybind")
     del sitemap["install-release-notes"]
+    for vt_section in (s for s in SECTIONS if s.startswith("vt-")):
+        sitemap["vt"].remove(vt_section.removeprefix("vt-"))
 
 
 sitemap: dict[str, list[str]] = {}

--- a/app/components/docs.py
+++ b/app/components/docs.py
@@ -41,7 +41,9 @@ class Entry(TypedDict):
     children: NotRequired[list[Entry]]
 
 
-def _load_children(sitemap: dict[str, list[str]], path: str, children: list[Entry]) -> None:
+def _load_children(
+    sitemap: dict[str, list[str]], path: str, children: list[Entry]
+) -> None:
     sitemap[path] = []
     for item in children:
         sitemap[path].append((page := item["path"].lstrip("/")) or "overview")


### PR DESCRIPTION
Closes #97.

# Summary

### Optional `message` parameter can now be supplied
<img src="https://github.com/user-attachments/assets/c3e23e87-9e35-4196-93ad-5b4e16c8a8ce" width="70%">

### More sections are now available
In particular:
* `vt/` subsections:
  * `vt-concepts`
  * `vt-control`
  * `vt-csi`
  * `vt-esc`
* `keybind` (linking to [Overview](https://ghostty.org/docs/config/keybind), [Trigger Sequences](https://ghostty.org/docs/config/keybind/sequence), etc.)
* `config` (linking to [Overview](https://ghostty.org/docs/config) etc.)

Unintentionally, there are now a few ways to get the same page, e.g. `(config, keybind)` and `(keybind, overview)` both lead to https://ghostty.org/docs/config/keybind.