### PR TITLE
feat: revamp entity mentions

### DIFF
--- a/app/components/entity_mentions.py
+++ b/app/components/entity_mentions.py
@@ -13,6 +13,7 @@ from github.Repository import Repository
 from app.setup import bot, config, gh
 from app.utils import is_dm, try_dm
 
+GITHUB_URL = "https://github.com"
 ENTITY_REGEX = re.compile(r"(?:\b(web|bot|main))?#(\d{1,6})(?!\.\d)\b")
 ENTITY_TEMPLATE = "**{kind} [#{entity.number}](<{entity.html_url}>):** {entity.title}"
 IGNORED_MESSAGE_TYPES = frozenset(
@@ -131,7 +132,16 @@ message_to_mentions: dict[discord.Message, discord.Message] = {}
 
 
 def _format_mention(entity: Entity, kind: EntityKind) -> str:
-    return ENTITY_TEMPLATE.format(kind=kind, entity=entity)
+    headline = ENTITY_TEMPLATE.format(kind=kind, entity=entity)
+
+    # Include author and creation date
+    author = entity.user.login
+    subtext = (
+        f"\n-# by [`{author}`](<{GITHUB_URL}/{author}>)"
+        f" on {entity.created_at:%b %d, %Y}\n"
+    )
+
+    return headline + subtext
 
 
 def _get_entities(message: discord.Message) -> tuple[str, int]:

--- a/app/components/entity_mentions.py
+++ b/app/components/entity_mentions.py
@@ -185,7 +185,7 @@ def _format_mention(entity: Entity, kind: EntityKind) -> str:
         answered = getattr(entity, "answered", False)
         emoji = entity_emojis.get("discussion_answered" if answered else "issue_draft")
 
-    return f"{emoji} {headline}\n{subtext}"
+    return f"{emoji or ":question:"} {headline}\n{subtext}"
 
 
 def _get_entities(message: discord.Message) -> tuple[str, int]:

--- a/app/components/entity_mentions.py
+++ b/app/components/entity_mentions.py
@@ -91,11 +91,15 @@ class TTLCache:
 
     def _fetch_entity(self, key: CacheKey) -> None:
         repo_name, entity_id = key
+        repo = REPOSITORIES[repo_name]
         try:
-            entity = REPOSITORIES[repo_name].get_issue(entity_id)
-            kind = "Pull Request" if entity.pull_request else "Issue"
+            entity = repo.get_issue(entity_id)
+            kind = "Issue"
+            if entity.pull_request:
+                entity = repo.get_pull(entity_id)
+                kind = "Pull Request"
         except github.UnknownObjectException:
-            entity = get_discussion(REPOSITORIES[repo_name], entity_id)
+            entity = get_discussion(repo, entity_id)
             kind = "Discussion"
         self._cache[key] = (dt.datetime.now(), kind, cast(Entity, entity))
 

--- a/app/components/entity_mentions.py
+++ b/app/components/entity_mentions.py
@@ -14,7 +14,7 @@ from app.setup import bot, config, gh
 from app.utils import is_dm, try_dm
 
 ENTITY_REGEX = re.compile(r"(?:\b(web|bot|main))?#(\d{1,6})(?!\.\d)\b")
-ENTITY_TEMPLATE = "**{kind} #{entity.number}:** {entity.title}\n<{entity.html_url}>\n"
+ENTITY_TEMPLATE = "**{kind} [#{entity.number}](<{entity.html_url}>):** {entity.title}"
 IGNORED_MESSAGE_TYPES = frozenset(
     (discord.MessageType.thread_created, discord.MessageType.channel_name_change)
 )

--- a/app/components/entity_mentions.py
+++ b/app/components/entity_mentions.py
@@ -137,11 +137,11 @@ def _format_mention(entity: Entity, kind: EntityKind) -> str:
     # Include author and creation date
     author = entity.user.login
     subtext = (
-        f"\n-# by [`{author}`](<{GITHUB_URL}/{author}>)"
+        f"-# by [`{author}`](<{GITHUB_URL}/{author}>)"
         f" on {entity.created_at:%b %d, %Y}\n"
     )
 
-    return headline + subtext
+    return f"{headline}\n{subtext}"
 
 
 def _get_entities(message: discord.Message) -> tuple[str, int]:

--- a/app/components/entity_mentions.py
+++ b/app/components/entity_mentions.py
@@ -122,6 +122,10 @@ entity_cache = TTLCache(1800)  # 30 minutes
 message_to_mentions: dict[discord.Message, discord.Message] = {}
 
 
+def _format_mention(entity: Entity, kind: EntityKind) -> str:
+    return ENTITY_TEMPLATE.format(kind=kind, entity=entity)
+
+
 def _get_entities(message: discord.Message) -> tuple[str, int]:
     matches = dict.fromkeys(m.groups() for m in ENTITY_REGEX.finditer(message.content))
     if len(matches) > 10:
@@ -138,7 +142,7 @@ def _get_entities(message: discord.Message) -> tuple[str, int]:
         if entity.number < 10 and repo_name is None:
             # Ignore single-digit mentions (likely a false positive)
             continue
-        entities.append(ENTITY_TEMPLATE.format(kind=kind, entity=entity))
+        entities.append(_format_mention(entity, kind))
     return "\n".join(dict.fromkeys(entities)), len(entities)
 
 

--- a/app/components/entity_mentions.py
+++ b/app/components/entity_mentions.py
@@ -33,6 +33,7 @@ query getDiscussion($number: Int!, $org: String!, $repo: String!) {
       user: author { login }
       created_at: createdAt
       html_url: url
+      answered: isAnswered
     }
   }
 }

--- a/app/core.py
+++ b/app/core.py
@@ -10,7 +10,7 @@ from sentry_sdk import capture_exception
 
 from app.components.autoclose import autoclose_solved_posts
 from app.components.docs import refresh_sitemap
-from app.components.entity_mentions import ENTITY_REGEX, handle_entities
+from app.components.entity_mentions import ENTITY_REGEX, handle_entities, load_emojis
 from app.components.message_filter import check_message_filters
 from app.setup import bot, config
 from app.utils import is_dm, is_mod, try_dm
@@ -18,6 +18,7 @@ from app.utils import is_dm, is_mod, try_dm
 
 @bot.event
 async def on_ready() -> None:
+    await load_emojis()
     print(f"Bot logged on as {bot.user}!")
     autoclose_solved_posts.start()
 


### PR DESCRIPTION
Closes #120

Before | After
------ | -----
![26874](https://github.com/user-attachments/assets/33902596-8468-455f-b885-8353108343fd) | ![84797](https://github.com/user-attachments/assets/07fa8892-68e3-4a8a-a972-20a195415551)

This requires (there's a fallback mechanism though) that the server has the required emojis beforehand (and all names must match to those in `EMOJI_NAMES`).\
The emoji pack: [emojis.zip](https://github.com/user-attachments/files/18330509/emojis.zip)

The bot will now also give a heads up if any mentions were omitted from the final message.

### Known issues
* mentioning a PR for the first time takes slightly longer because the bot needs to do a second request (until now we checked if an entity is a PR by checking the `Issue.pull_request` field...)
* all of this new formatting doesn't allow for as many mentions in one message (one entity now takes over twice as many bytes <sub>(hence the "After" screenshot needing 2 messages)</sub>), but it's not a huge deal as pretty much nobody mentions this many realistically
