### PR TITLE
feat: send back the message content when filtered

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ The bot will delete any message:
 It will also DM users about the deletion and provide an explanation to make it
 less confusing:
 
-<img src="https://github.com/user-attachments/assets/263c59cb-19b5-4308-80d8-de464884692f" alt="Message filter notification" width="50%">
+<img src="https://github.com/user-attachments/assets/2064111f-6e64-477c-b564-4034c5245adc" alt="Message filter notification" width="50%">
 
 ## Moving messages
 

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ The bot will delete any message:
 It will also DM users about the deletion and provide an explanation to make it
 less confusing:
 
-<img src="https://github.com/user-attachments/assets/2064111f-6e64-477c-b564-4034c5245adc" alt="Message filter notification" width="50%">
+<img src="https://github.com/user-attachments/assets/2064111f-6e64-477c-b564-4034c5245adc" alt="Message filter notification" width="80%">
 
 ## Moving messages
 

--- a/app/components/message_filter.py
+++ b/app/components/message_filter.py
@@ -66,7 +66,7 @@ async def check_message_filters(message: discord.Message) -> bool:
         )
         if content_size := len(message.content):
             notification += MESSAGE_CONTENT_NOTICE
-        await try_dm(message.author, notification, silent=True)
+        await try_dm(message.author, notification, silent=content_size > 0)
 
         if content_size > 2000:
             # The user has Nitro but the bot doesn't,

--- a/app/components/message_filter.py
+++ b/app/components/message_filter.py
@@ -45,9 +45,14 @@ async def check_message_filters(message: discord.Message) -> bool:
     for msg_filter in MESSAGE_FILTERS:
         if message.channel.id != msg_filter.channel_id or msg_filter.filter(message):
             continue
+
         await message.delete()
+
+        # Don't DM the user if it's a system message
+        # (e.g. "@user started a thread")
         if message.type not in REGULAR_MESSAGE_TYPES:
             continue
+
         assert isinstance(message.channel, discord.TextChannel)
         await try_dm(
             message.author,

--- a/app/utils.py
+++ b/app/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import io
 from textwrap import shorten
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import discord
 
@@ -138,11 +138,11 @@ def is_helper(member: discord.Member) -> bool:
     return member.get_role(config.HELPER_ROLE_ID) is not None
 
 
-async def try_dm(account: Account, content: str) -> None:
+async def try_dm(account: Account, content: str, **extras: Any) -> None:
     if account.bot:
         return
     try:
-        await account.send(content)
+        await account.send(content, **extras)
     except discord.Forbidden:
         print(f"Failed to DM {account} with: {shorten(content, width=50)}")
 


### PR DESCRIPTION
Closes #119

If the deleted message had any content, the bot will send it back to the user with the notification (it sends 3 messages so it's easier to use the "Copy Text" thing, but 2 of them are silent so the sound plays just once).

The behavior for no content is unchanged (the message below the red line wasn't cropped 😉).

![44092](https://github.com/user-attachments/assets/2064111f-6e64-477c-b564-4034c5245adc)