### PR TITLE
fix(nix): Add hatch-fancy-pypi-readme to hishel build inputs 

### DIFF
--- a/nix/python-app.nix
+++ b/nix/python-app.nix
@@ -1,15 +1,21 @@
-{ poetry2nix
-, lib
-, stdenv
-, substituteAll
-, writeShellScriptBin
-
-, python3
-}:
-
-let
+{
+  poetry2nix,
+  lib,
+  stdenv,
+  substituteAll,
+  writeShellScriptBin,
+  python3,
+}: let
   overrides = poetry2nix.overrides.withDefaults (self: super: {
-    # None yet
+    hishel = super.hishel.overridePythonAttrs (
+      old: {
+        nativeBuildInputs =
+          old.nativeBuildInputs
+          ++ [
+            self.hatch-fancy-pypi-readme
+          ];
+      }
+    );
   });
 in {
   # This is the main runnable app that only includes runtime dependencies.


### PR DESCRIPTION
I can revert the formatting if thats desired. 