### PR TITLE
perf: improve entity fetching flow

### DIFF
--- a/app/components/entity_mentions/cache.py
+++ b/app/components/entity_mentions/cache.py
@@ -31,17 +31,15 @@ class TTRCache:
 
     async def _fetch_entity(self, key: CacheKey) -> None:
         repo_name, entity_id = key
-        repo_path = (config.GITHUB_ORG, config.GITHUB_REPOS[repo_name])
+        signature = (config.GITHUB_ORG, config.GITHUB_REPOS[repo_name], entity_id)
         try:
-            entity = (await gh.rest.issues.async_get(*repo_path, entity_id)).parsed_data
+            entity = (await gh.rest.issues.async_get(*signature)).parsed_data
             kind = "Issue"
             if entity.pull_request:
-                entity = (
-                    await gh.rest.pulls.async_get(*repo_path, entity_id)
-                ).parsed_data
+                entity = (await gh.rest.pulls.async_get(*signature)).parsed_data
                 kind = "Pull Request"
         except RequestFailed:
-            entity = await get_discussion(*repo_path, entity_id)
+            entity = await get_discussion(*signature)
             kind = "Discussion"
         self._cache[key] = (dt.datetime.now(), kind, cast(Entity, entity))
 

--- a/app/components/entity_mentions/cache.py
+++ b/app/components/entity_mentions/cache.py
@@ -51,7 +51,8 @@ class TTRCache:
         if dt.datetime.now() - timestamp >= self._ttr:
             self._fetch_entity(key)
 
-    def __getitem__(self, key: CacheKey) -> tuple[EntityKind, Entity]:
+    def get(self, repo: RepoName, number: int) -> tuple[EntityKind, Entity]:
+        key = repo, number
         self._refresh(key)
         _, kind, entity = self._cache[key]
         return kind, entity

--- a/app/components/entity_mentions/cache.py
+++ b/app/components/entity_mentions/cache.py
@@ -29,31 +29,33 @@ class TTRCache:
         self._ttr = dt.timedelta(seconds=ttr)
         self._cache: dict[CacheKey, tuple[dt.datetime, EntityKind, Entity]] = {}
 
-    def _fetch_entity(self, key: CacheKey) -> None:
+    async def _fetch_entity(self, key: CacheKey) -> None:
         repo_name, entity_id = key
         repo_path = (config.GITHUB_ORG, config.GITHUB_REPOS[repo_name])
         try:
-            entity = gh.rest.issues.get(*repo_path, entity_id).parsed_data
+            entity = (await gh.rest.issues.async_get(*repo_path, entity_id)).parsed_data
             kind = "Issue"
             if entity.pull_request:
-                entity = gh.rest.pulls.get(*repo_path, entity_id).parsed_data
+                entity = (
+                    await gh.rest.pulls.async_get(*repo_path, entity_id)
+                ).parsed_data
                 kind = "Pull Request"
         except RequestFailed:
-            entity = get_discussion(*repo_path, entity_id)
+            entity = await get_discussion(*repo_path, entity_id)
             kind = "Discussion"
         self._cache[key] = (dt.datetime.now(), kind, cast(Entity, entity))
 
-    def _refresh(self, key: CacheKey) -> None:
+    async def _refresh(self, key: CacheKey) -> None:
         if key not in self._cache:
-            self._fetch_entity(key)
+            await self._fetch_entity(key)
             return
         timestamp, *_ = self._cache[key]
         if dt.datetime.now() - timestamp >= self._ttr:
-            self._fetch_entity(key)
+            await self._fetch_entity(key)
 
-    def get(self, repo: RepoName, number: int) -> tuple[EntityKind, Entity]:
+    async def get(self, repo: RepoName, number: int) -> tuple[EntityKind, Entity]:
         key = repo, number
-        self._refresh(key)
+        await self._refresh(key)
         _, kind, entity = self._cache[key]
         return kind, entity
 

--- a/app/components/entity_mentions/discussions.py
+++ b/app/components/entity_mentions/discussions.py
@@ -19,8 +19,8 @@ query getDiscussion($number: Int!, $org: String!, $repo: String!) {
 """
 
 
-def get_discussion(org: str, name: str, number: int) -> SimpleNamespace:
-    resp = gh.graphql.request(
+async def get_discussion(org: str, name: str, number: int) -> SimpleNamespace:
+    resp = await gh.graphql.arequest(
         DISCUSSION_QUERY, variables={"number": number, "org": org, "repo": name}
     )
     data = resp["repository"]["discussion"]

--- a/app/components/entity_mentions/fmt.py
+++ b/app/components/entity_mentions/fmt.py
@@ -79,7 +79,7 @@ def entity_message(message: discord.Message) -> tuple[str, int]:
     for repo_name, number_ in matches:
         number = int(number_)
         try:
-            kind, entity = entity_cache[cast(RepoName, repo_name or "main"), number]
+            kind, entity = entity_cache.get(cast(RepoName, repo_name or "main"), number)
         except KeyError:
             continue
         if entity.number < 10 and repo_name is None:

--- a/app/components/entity_mentions/integration.py
+++ b/app/components/entity_mentions/integration.py
@@ -72,7 +72,7 @@ async def reply_with_entities(message: discord.Message) -> None:
         )
         return
 
-    msg_content, entity_count = entity_message(message)
+    msg_content, entity_count = await entity_message(message)
     if not entity_count:
         return
 
@@ -95,8 +95,8 @@ async def on_message_delete(message: discord.Message) -> None:
 async def on_message_edit(before: discord.Message, after: discord.Message) -> None:
     if before.content == after.content:
         return
-    old_entites = entity_message(before)
-    new_entities = entity_message(after)
+    old_entites = await entity_message(before)
+    new_entities = await entity_message(after)
     if old_entites == new_entities:
         # Message changed but mentions are the same
         return


### PR DESCRIPTION
Built on top of #129. The wait time decreases significantly when multiple entities are mentioned for the first time in a message:
![image](https://github.com/user-attachments/assets/d6f21e8f-64b2-416e-850a-89193403e19c)