### PR TITLE
Use a Discord timestamp for entity mention dates

### DIFF
--- a/app/components/entity_mentions/fmt.py
+++ b/app/components/entity_mentions/fmt.py
@@ -50,10 +50,11 @@ def _format_mention(entity: Entity, kind: EntityKind) -> str:
     #    0                   1      2     3       4
     domain, owner, name, *_ = entity.html_url.rsplit("/", 4)
     author = entity.user.login
+    timestamp = int(entity.created_at.timestamp())
     subtext = (
         f"-# by [`{author}`](<{domain}/{author}>)"
         f" in [`{owner}/{name}`](<{"/".join((domain, owner, name))}>)"
-        f" on {entity.created_at:%b %d, %Y}\n"
+        f" on <t:{timestamp}:D> (<t:{timestamp}:R>)\n"
     )
 
     if isinstance(entity, Issue):


### PR DESCRIPTION
Closes #139, based on #142.

I'm not convinced it looks better, though.  In particular, I'm not partial to the grey background applied to timestamps; it does not fit in with the rest of the subtext.
![A screenshot demoing the change.](https://github.com/user-attachments/assets/7e2923f0-441d-49d9-898f-5af050664e2b)
<sup>**First**: before. **Second**: only `:D`. **Third**: `:D` with `:R` in brackets; i.e. this PR[^1].</sup>

[^1]: Note: I took this screenshot before I switched from targetting the [`main`] branch to the [`global-entity-mentions`] branch from #142.

[`main`]: https://github.com/ghostty-org/discord-bot/tree/main
[`global-entity-mentions`]: https://github.com/ghostty-org/discord-bot/tree/global-entity-mentions
