### PR TITLE
feat: add Zig syntax highlighting

### DIFF
--- a/app/components/__init__.py
+++ b/app/components/__init__.py
@@ -6,6 +6,7 @@ from . import (
     entity_mentions,
     message_filter,
     move_message,
+    zig_codeblocks,
 )
 
 __all__ = (
@@ -16,4 +17,5 @@ __all__ = (
     "entity_mentions",
     "message_filter",
     "move_message",
+    "zig_codeblocks",
 )

--- a/app/components/entity_mentions/__init__.py
+++ b/app/components/entity_mentions/__init__.py
@@ -1,9 +1,14 @@
 from .fmt import entity_message, load_emojis
-from .integration import entity_mention_edit_handler, reply_with_entities
+from .integration import (
+    entity_mention_delete_handler,
+    entity_mention_edit_handler,
+    reply_with_entities,
+)
 from .resolution import ENTITY_REGEX
 
 __all__ = (
     "ENTITY_REGEX",
+    "entity_mention_delete_handler",
     "entity_mention_edit_handler",
     "entity_message",
     "load_emojis",

--- a/app/components/entity_mentions/__init__.py
+++ b/app/components/entity_mentions/__init__.py
@@ -1,9 +1,10 @@
 from .fmt import entity_message, load_emojis
-from .integration import reply_with_entities
+from .integration import entity_mention_edit_handler, reply_with_entities
 from .resolution import ENTITY_REGEX
 
 __all__ = (
     "ENTITY_REGEX",
+    "entity_mention_edit_handler",
     "entity_message",
     "load_emojis",
     "reply_with_entities",

--- a/app/components/entity_mentions/integration.py
+++ b/app/components/entity_mentions/integration.py
@@ -91,8 +91,9 @@ async def on_message_delete(message: discord.Message) -> None:
         await reply.delete()
 
 
-@bot.event
-async def on_message_edit(before: discord.Message, after: discord.Message) -> None:
+async def entity_mention_edit_handler(
+    before: discord.Message, after: discord.Message
+) -> None:
     if before.content == after.content:
         return
     old_entites = await entity_message(before)

--- a/app/components/entity_mentions/integration.py
+++ b/app/components/entity_mentions/integration.py
@@ -23,7 +23,7 @@ class DeleteMention(discord.ui.View):
         style=discord.ButtonStyle.gray,
     )
     async def delete(
-        self, interaction: discord.Interaction, _button: discord.ui.Button
+        self, interaction: discord.Interaction, _: discord.ui.Button
     ) -> None:
         assert not is_dm(interaction.user)
         if interaction.user.id == self.message.author.id or is_mod(interaction.user):

--- a/app/components/entity_mentions/integration.py
+++ b/app/components/entity_mentions/integration.py
@@ -1,11 +1,9 @@
-import asyncio
 import datetime as dt
-from contextlib import suppress
 
 import discord
 
 from app.setup import bot
-from app.utils import is_dm, is_mod, try_dm
+from app.utils import is_dm, is_mod, remove_view_after_timeout, try_dm
 
 from .fmt import entity_message
 
@@ -55,12 +53,6 @@ def _unlink_original_message(message: discord.Message) -> None:
         del message_to_mentions[original_message]
 
 
-async def remove_button_after_timeout(message: discord.Message) -> None:
-    await asyncio.sleep(30)
-    with suppress(discord.NotFound, discord.HTTPException):
-        await message.edit(view=None)
-
-
 async def reply_with_entities(message: discord.Message) -> None:
     if message.author.bot or message.type in IGNORED_MESSAGE_TYPES:
         return
@@ -80,7 +72,7 @@ async def reply_with_entities(message: discord.Message) -> None:
         msg_content, mention_author=False, view=DeleteMention(message, entity_count)
     )
     message_to_mentions[message] = sent_message
-    await remove_button_after_timeout(sent_message)
+    await remove_view_after_timeout(sent_message)
 
 
 @bot.event
@@ -128,4 +120,4 @@ async def entity_mention_edit_handler(
         view=DeleteMention(after, count),
         allowed_mentions=discord.AllowedMentions.none(),
     )
-    await remove_button_after_timeout(reply)
+    await remove_view_after_timeout(reply)

--- a/app/components/entity_mentions/integration.py
+++ b/app/components/entity_mentions/integration.py
@@ -2,7 +2,6 @@ import datetime as dt
 
 import discord
 
-from app.setup import bot
 from app.utils import is_dm, is_mod, remove_view_after_timeout, try_dm
 
 from .fmt import entity_message
@@ -75,8 +74,7 @@ async def reply_with_entities(message: discord.Message) -> None:
     await remove_view_after_timeout(sent_message)
 
 
-@bot.event
-async def on_message_delete(message: discord.Message) -> None:
+async def entity_mention_delete_handler(message: discord.Message) -> None:
     if message.author.bot:
         _unlink_original_message(message)
     elif (reply := message_to_mentions.get(message)) is not None:

--- a/app/components/zig_codeblocks.py
+++ b/app/components/zig_codeblocks.py
@@ -17,9 +17,10 @@ THEME = DEFAULT_THEME.copy()
 THEME.comments = None
 
 message_to_codeblocks: dict[discord.Message, discord.Message] = {}
+frozen_messages = set[discord.Message]()
 
 
-class DismissCode(discord.ui.View):
+class ZigCodeblockActions(discord.ui.View):
     def __init__(self, message: discord.Message) -> None:
         super().__init__()
         self._message = message
@@ -41,6 +42,29 @@ class DismissCode(discord.ui.View):
         await interaction.response.send_message(
             "You can't dismiss this message.", ephemeral=True
         )
+
+    @discord.ui.button(
+        label="Freeze",
+        emoji="❄️",
+        style=discord.ButtonStyle.gray,
+    )
+    async def freeze(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        assert not is_dm(interaction.user)
+        if interaction.user.id == self._message.author.id or is_mod(interaction.user):
+            frozen_messages.add(self._message)
+            button.disabled = True
+            await interaction.response.edit_message(view=self)
+            await interaction.followup.send(
+                "Message frozen. I will no longer react to"
+                " what happens to your original message.",
+                ephemeral=True,
+            )
+        else:
+            await interaction.response.send_message(
+                "You can't freeze this message.", ephemeral=True
+            )
 
 
 async def _prepare_reply(
@@ -77,7 +101,7 @@ async def check_for_zig_code(message: discord.Message) -> None:
         return
     reply = await message.reply(
         content,
-        view=DismissCode(message),
+        view=ZigCodeblockActions(message),
         files=files,
         mention_author=False,
     )
@@ -97,14 +121,14 @@ async def zig_codeblock_edit_handler(
         return
 
     if (reply := message_to_codeblocks.get(before)) is None:
-        if not old_content:
+        if not (old_content or before in frozen_messages):
             # There was no code before, so treat this as a new message.
             # Note: No new attachments can appear, their count can only decrease.
             await check_for_zig_code(after)
         # The message was removed from the M2C map at some point
         return
 
-    if not (new_content or new_files):
+    if not (new_content or new_files or before in frozen_messages):
         # All code was edited out
         del message_to_codeblocks[before]
         await reply.delete()
@@ -114,12 +138,16 @@ async def zig_codeblock_edit_handler(
     # stop reacting to it and remove its M2C entry.
     last_updated = dt.datetime.now(tz=dt.UTC) - (reply.edited_at or reply.created_at)
     if last_updated > dt.timedelta(hours=24):
+        frozen_messages.discard(before)
         del message_to_codeblocks[before]
+        return
+
+    if before in frozen_messages:
         return
 
     await reply.edit(
         content=new_content,
-        view=DismissCode(after),
+        view=ZigCodeblockActions(after),
         attachments=new_files,
         allowed_mentions=discord.AllowedMentions.none(),
     )
@@ -132,11 +160,15 @@ def _unlink_original_message(message: discord.Message) -> None:
         None,
     )
     if original_message is not None:
+        frozen_messages.discard(original_message)
         del message_to_codeblocks[original_message]
 
 
 async def zig_codeblock_delete_handler(message: discord.Message) -> None:
     if message.author.bot:
         _unlink_original_message(message)
-    if (reply := message_to_codeblocks.get(message)) is not None:
+    if not (
+        (reply := message_to_codeblocks.get(message)) is None
+        or message in frozen_messages
+    ):
         await reply.delete()

--- a/app/components/zig_codeblocks.py
+++ b/app/components/zig_codeblocks.py
@@ -215,7 +215,7 @@ async def zig_codeblock_edit_handler(
 
     for reply, new_content in zip_longest(replies, new_contents, fillvalue=None):
         if not (reply is None or new_content is None):
-            if reply is replies[-1] and len(replies) == len(new_contents):
+            if new_content is new_contents[-1] and len(replies) >= len(new_contents):
                 view = ZigCodeblockActions(after)
                 files = new_files
             else:

--- a/app/components/zig_codeblocks.py
+++ b/app/components/zig_codeblocks.py
@@ -213,6 +213,7 @@ async def zig_codeblock_edit_handler(
     if before in frozen_messages:
         return
 
+    saved_msg: discord.Message | None = None
     for reply, new_content in zip_longest(replies, new_contents, fillvalue=None):
         if not (reply is None or new_content is None):
             if new_content is new_contents[-1] and len(replies) >= len(new_contents):
@@ -228,7 +229,7 @@ async def zig_codeblock_edit_handler(
                 allowed_mentions=discord.AllowedMentions.none(),
             )
             if view is not None:
-                await remove_view_after_timeout(reply, 60.0)
+                saved_msg = reply
             continue
         if reply is None:
             # Out of replies, codeblocks still left -> Create new replies
@@ -241,7 +242,7 @@ async def zig_codeblock_edit_handler(
                     allowed_mentions=discord.AllowedMentions.none(),
                 )
                 message_to_codeblocks[after].append(msg)
-                await remove_view_after_timeout(msg, 60.0)
+                saved_msg = msg
             else:
                 # Not the last new reply
                 msg = await after.channel.send(
@@ -251,6 +252,8 @@ async def zig_codeblock_edit_handler(
         else:
             # Out of codeblocks, replies still left -> Delete remaining replies
             await reply.delete()
+    if saved_msg is not None:
+        await remove_view_after_timeout(saved_msg, 60.0)
 
 
 def _unlink_original_message(message: discord.Message) -> None:

--- a/app/components/zig_codeblocks.py
+++ b/app/components/zig_codeblocks.py
@@ -215,14 +215,16 @@ async def zig_codeblock_edit_handler(
 
     for reply, new_content in zip_longest(replies, new_contents, fillvalue=None):
         if not (reply is None or new_content is None):
-            view = (
-                ZigCodeblockActions(after)
-                if reply is replies[-1] and len(replies) == len(new_contents)
-                else None
-            )
+            if reply is replies[-1] and len(replies) == len(new_contents):
+                view = ZigCodeblockActions(after)
+                files = new_files
+            else:
+                view = None
+                files = discord.utils.MISSING
             await reply.edit(
                 content=new_content,
                 view=view,
+                attachments=files,
                 allowed_mentions=discord.AllowedMentions.none(),
             )
             if view is not None:

--- a/app/components/zig_codeblocks.py
+++ b/app/components/zig_codeblocks.py
@@ -1,7 +1,12 @@
+from io import BytesIO
+
 import discord
-from zig_codeblocks import extract_codeblocks, process_markdown
+from zig_codeblocks import extract_codeblocks, highlight_zig_code, process_markdown
 
 from app.utils import is_dm, is_mod
+
+MAX_CONTENT = 51_200  # 50 KiB
+MAX_ZIG_FILE_SIZE = 8_388_608  # 8 MiB
 
 
 class DismissCode(discord.ui.View):
@@ -29,10 +34,30 @@ class DismissCode(discord.ui.View):
 
 
 async def check_for_zig_code(message: discord.Message) -> None:
+    attachments = [
+        discord.File(
+            BytesIO(
+                highlight_zig_code((await att.read()).decode()[:MAX_CONTENT]).encode()
+            ),
+            att.filename + ".ansi",
+        )
+        for att in message.attachments
+        if att.filename.endswith(".zig") and att.size <= MAX_ZIG_FILE_SIZE
+    ]
     codeblocks = list(extract_codeblocks(message.content))
     if codeblocks and any(block.lang == "zig" for block in codeblocks):
         zig_code = process_markdown(message.content, only_code=True)
         if len(zig_code) <= 2000:
             await message.reply(
-                zig_code, view=DismissCode(message), mention_author=False
+                zig_code,
+                view=DismissCode(message),
+                files=attachments,
+                mention_author=False,
             )
+    elif attachments:
+        await message.reply(
+            'Click "View whole file" to see the highlighting.',
+            view=DismissCode(message),
+            files=attachments,
+            mention_author=False,
+        )

--- a/app/components/zig_codeblocks.py
+++ b/app/components/zig_codeblocks.py
@@ -36,9 +36,7 @@ class DismissCode(discord.ui.View):
 async def check_for_zig_code(message: discord.Message) -> None:
     attachments = [
         discord.File(
-            BytesIO(
-                highlight_zig_code((await att.read()).decode()[:MAX_CONTENT]).encode()
-            ),
+            BytesIO(highlight_zig_code((await att.read())[:MAX_CONTENT]).encode()),
             att.filename + ".ansi",
         )
         for att in message.attachments

--- a/app/components/zig_codeblocks.py
+++ b/app/components/zig_codeblocks.py
@@ -1,0 +1,38 @@
+import discord
+from zig_codeblocks import extract_codeblocks, process_markdown
+
+from app.utils import is_dm, is_mod
+
+
+class DismissCode(discord.ui.View):
+    def __init__(self, message: discord.Message) -> None:
+        super().__init__()
+        self._message = message
+
+    @discord.ui.button(
+        label="Dismiss",
+        emoji="❌",
+        style=discord.ButtonStyle.gray,
+    )
+    async def dismiss(
+        self, interaction: discord.Interaction, _button: discord.ui.Button
+    ) -> None:
+        assert not is_dm(interaction.user)
+        if interaction.user.id == self._message.author.id or is_mod(interaction.user):
+            assert interaction.message
+            await interaction.message.delete()
+            return
+
+        await interaction.response.send_message(
+            "You can't dismiss this message.", ephemeral=True
+        )
+
+
+async def check_for_zig_code(message: discord.Message) -> None:
+    codeblocks = list(extract_codeblocks(message.content))
+    if codeblocks and any(block.lang == "zig" for block in codeblocks):
+        zig_code = process_markdown(message.content, only_code=True)
+        if len(zig_code) <= 2000:
+            await message.reply(
+                zig_code, view=DismissCode(message), mention_author=False
+            )

--- a/app/components/zig_codeblocks.py
+++ b/app/components/zig_codeblocks.py
@@ -14,7 +14,7 @@ from app.utils import is_dm, is_mod, remove_view_after_timeout
 MAX_CONTENT = 51_200  # 50 KiB
 MAX_ZIG_FILE_SIZE = 8_388_608  # 8 MiB
 THEME = DEFAULT_THEME.copy()
-THEME.comments = None
+del THEME["comments"]
 
 message_to_codeblocks: dict[discord.Message, discord.Message] = {}
 frozen_messages = set[discord.Message]()

--- a/app/components/zig_codeblocks.py
+++ b/app/components/zig_codeblocks.py
@@ -35,8 +35,15 @@ frozen_messages = set[discord.Message]()
 def custom_process_markdown(source: str | bytes, *, only_code: bool = False) -> str:
     return (
         process_markdown(source, THEME, only_code=only_code)
-        # Discord is cursed and disables ANSI highlighting entirely if there are
-        # more than 14 (or 30, seems to vary) slashes since last SGR sequence.
+        # From Qwerasd:
+        #   I got distracted and checked the Discord source and this is the logic,
+        #   highlighting is disabled under these circumstances:
+        #   * The src contains 15 or more consecutive slashes
+        #   * The src contains a line with 1000 or more characters
+        #   * The src contains more than 30 slashes with anything in between as long as
+        #     it's not a line that isn't in the form ^\s*\/\/.* and contains a character
+        #     other than /
+        # These replace calls are an attempt to work around these limitations.
         .replace("///", "\x1b[0m///")
         .replace("// ", "\x1b[0m// ")
     )

--- a/app/components/zig_codeblocks.py
+++ b/app/components/zig_codeblocks.py
@@ -36,6 +36,8 @@ def custom_process_markdown(source: str | bytes, *, only_code: bool = False) -> 
     return (
         process_markdown(source, THEME, only_code=only_code)
         # From Qwerasd:
+        #   Oh is it a safeguard against catastrophic backtracking?
+        #   [...]
         #   I got distracted and checked the Discord source and this is the logic,
         #   highlighting is disabled under these circumstances:
         #   * The src contains 15 or more consecutive slashes

--- a/app/components/zig_codeblocks.py
+++ b/app/components/zig_codeblocks.py
@@ -82,6 +82,7 @@ async def check_for_zig_code(message: discord.Message) -> None:
         mention_author=False,
     )
     message_to_codeblocks[message] = reply
+    await remove_view_after_timeout(reply)
 
 
 async def zig_codeblock_edit_handler(
@@ -123,3 +124,19 @@ async def zig_codeblock_edit_handler(
         allowed_mentions=discord.AllowedMentions.none(),
     )
     await remove_view_after_timeout(reply)
+
+
+def _unlink_original_message(message: discord.Message) -> None:
+    original_message = next(
+        (msg for msg, reply in message_to_codeblocks.items() if reply == message),
+        None,
+    )
+    if original_message is not None:
+        del message_to_codeblocks[original_message]
+
+
+async def zig_codeblock_delete_handler(message: discord.Message) -> None:
+    if message.author.bot:
+        _unlink_original_message(message)
+    if (reply := message_to_codeblocks.get(message)) is not None:
+        await reply.delete()

--- a/app/components/zig_codeblocks.py
+++ b/app/components/zig_codeblocks.py
@@ -134,11 +134,13 @@ async def _prepare_reply(
         )
 
     codeblocks = list(extract_codeblocks(message.content))
+    file_highlight_note = 'Click "View whole file" to see the highlighting.'
     if codeblocks and any(block.lang == "zig" for block in codeblocks):
         zig_code = custom_process_markdown(message.content, only_code=True)
+        zig_code += f"\n{file_highlight_note}" if attachments else ""
         return _split_codeblocks(zig_code), attachments
     elif attachments:
-        return ['Click "View whole file" to see the highlighting.'], attachments
+        return [file_highlight_note], attachments
     return [], []
 
 

--- a/app/components/zig_codeblocks.py
+++ b/app/components/zig_codeblocks.py
@@ -154,7 +154,7 @@ async def check_for_zig_code(message: discord.Message) -> None:
             mention_author=False,
         )
         message_to_codeblocks[message].append(reply)
-        await remove_view_after_timeout(reply)
+        await remove_view_after_timeout(reply, 60.0)
         return
 
     first_msg = await message.reply(msg_contents[0], mention_author=False)
@@ -168,7 +168,7 @@ async def check_for_zig_code(message: discord.Message) -> None:
         msg_contents[-1], view=ZigCodeblockActions(message), files=files
     )
     message_to_codeblocks[message].append(final_msg)
-    await remove_view_after_timeout(final_msg)
+    await remove_view_after_timeout(final_msg, 60.0)
 
 
 async def zig_codeblock_edit_handler(
@@ -223,7 +223,7 @@ async def zig_codeblock_edit_handler(
                 allowed_mentions=discord.AllowedMentions.none(),
             )
             if view is not None:
-                await remove_view_after_timeout(reply)
+                await remove_view_after_timeout(reply, 60.0)
             continue
         if reply is None:
             # Out of replies, codeblocks still left -> Create new replies
@@ -236,7 +236,7 @@ async def zig_codeblock_edit_handler(
                     allowed_mentions=discord.AllowedMentions.none(),
                 )
                 message_to_codeblocks[after].append(msg)
-                await remove_view_after_timeout(msg)
+                await remove_view_after_timeout(msg, 60.0)
             else:
                 # Not the last new reply
                 msg = await after.channel.send(

--- a/app/components/zig_codeblocks.py
+++ b/app/components/zig_codeblocks.py
@@ -149,7 +149,7 @@ async def _prepare_reply(
         zig_code = custom_process_markdown(message.content, only_code=True)
         zig_code += f"\n{file_highlight_note}" if attachments else ""
         return _split_codeblocks(zig_code), attachments
-    elif attachments:
+    if attachments:
         return [file_highlight_note], attachments
     return [], []
 

--- a/app/components/zig_codeblocks.py
+++ b/app/components/zig_codeblocks.py
@@ -49,6 +49,7 @@ class ZigCodeblockActions(discord.ui.View):
         self.replace.disabled = (
             len(message_to_codeblocks[message]) > 1
             or len(self._replaced_message_content) > 2000
+            or len(message.attachments) > 0
         )
 
     @discord.ui.button(

--- a/app/components/zig_codeblocks.py
+++ b/app/components/zig_codeblocks.py
@@ -1,12 +1,19 @@
 from io import BytesIO
 
 import discord
-from zig_codeblocks import extract_codeblocks, highlight_zig_code, process_markdown
+from zig_codeblocks import (
+    DEFAULT_THEME,
+    extract_codeblocks,
+    highlight_zig_code,
+    process_markdown,
+)
 
 from app.utils import is_dm, is_mod
 
 MAX_CONTENT = 51_200  # 50 KiB
 MAX_ZIG_FILE_SIZE = 8_388_608  # 8 MiB
+THEME = DEFAULT_THEME.copy()
+THEME.comments = None
 
 
 class DismissCode(discord.ui.View):
@@ -36,7 +43,9 @@ class DismissCode(discord.ui.View):
 async def check_for_zig_code(message: discord.Message) -> None:
     attachments = [
         discord.File(
-            BytesIO(highlight_zig_code((await att.read())[:MAX_CONTENT]).encode()),
+            BytesIO(
+                highlight_zig_code((await att.read())[:MAX_CONTENT], THEME).encode()
+            ),
             att.filename + ".ansi",
         )
         for att in message.attachments
@@ -44,7 +53,7 @@ async def check_for_zig_code(message: discord.Message) -> None:
     ]
     codeblocks = list(extract_codeblocks(message.content))
     if codeblocks and any(block.lang == "zig" for block in codeblocks):
-        zig_code = process_markdown(message.content, only_code=True)
+        zig_code = process_markdown(message.content, THEME, only_code=True)
         if len(zig_code) <= 2000:
             await message.reply(
                 zig_code,

--- a/app/components/zig_codeblocks.py
+++ b/app/components/zig_codeblocks.py
@@ -22,6 +22,7 @@ from app.utils import (
 
 MAX_CONTENT = 51_200  # 50 KiB
 MAX_ZIG_FILE_SIZE = 8_388_608  # 8 MiB
+VIEW_TIMEOUT = 60.0
 
 SGR_PATTERN = re.compile(r"\x1b\[[0-9;]+m")
 THEME = DEFAULT_THEME.copy()
@@ -157,7 +158,7 @@ async def check_for_zig_code(message: discord.Message) -> None:
             mention_author=False,
         )
         message_to_codeblocks[message].append(reply)
-        await remove_view_after_timeout(reply, 60.0)
+        await remove_view_after_timeout(reply, VIEW_TIMEOUT)
         return
 
     first_msg = await message.reply(msg_contents[0], mention_author=False)
@@ -171,7 +172,7 @@ async def check_for_zig_code(message: discord.Message) -> None:
         msg_contents[-1], view=ZigCodeblockActions(message), files=files
     )
     message_to_codeblocks[message].append(final_msg)
-    await remove_view_after_timeout(final_msg, 60.0)
+    await remove_view_after_timeout(final_msg, VIEW_TIMEOUT)
 
 
 async def zig_codeblock_edit_handler(
@@ -253,7 +254,7 @@ async def zig_codeblock_edit_handler(
             # Out of codeblocks, replies still left -> Delete remaining replies
             await reply.delete()
     if saved_msg is not None:
-        await remove_view_after_timeout(saved_msg, 60.0)
+        await remove_view_after_timeout(saved_msg, VIEW_TIMEOUT)
 
 
 def _unlink_original_message(message: discord.Message) -> None:

--- a/app/components/zig_codeblocks.py
+++ b/app/components/zig_codeblocks.py
@@ -58,7 +58,7 @@ class ZigCodeblockActions(discord.ui.View):
         style=discord.ButtonStyle.gray,
     )
     async def dismiss(
-        self, interaction: discord.Interaction, _button: discord.ui.Button
+        self, interaction: discord.Interaction, _: discord.ui.Button
     ) -> None:
         assert not is_dm(interaction.user)
         if interaction.user.id == self._message.author.id or is_mod(interaction.user):
@@ -99,7 +99,7 @@ class ZigCodeblockActions(discord.ui.View):
         style=discord.ButtonStyle.gray,
     )
     async def replace(
-        self, interaction: discord.Interaction, button: discord.ui.Button
+        self, interaction: discord.Interaction, _: discord.ui.Button
     ) -> None:
         assert interaction.message
         channel = interaction.message.channel

--- a/app/core.py
+++ b/app/core.py
@@ -15,7 +15,7 @@ from app.components.entity_mentions import (
     reply_with_entities,
 )
 from app.components.message_filter import check_message_filters
-from app.components.zig_codeblocks import check_for_zig_code
+from app.components.zig_codeblocks import check_for_zig_code, zig_codeblock_edit_handler
 from app.setup import bot, config
 from app.utils import is_dm, is_mod, try_dm
 
@@ -74,6 +74,7 @@ async def on_message(message: discord.Message) -> None:
 @bot.event
 async def on_message_edit(before: discord.Message, after: discord.Message) -> None:
     await entity_mention_edit_handler(before, after)
+    await zig_codeblock_edit_handler(before, after)
 
 
 async def sync(bot: commands.Bot, message: discord.Message) -> None:

--- a/app/core.py
+++ b/app/core.py
@@ -14,6 +14,7 @@ from app.components.entity_mentions import (
     reply_with_entities,
 )
 from app.components.message_filter import check_message_filters
+from app.components.zig_codeblocks import check_for_zig_code
 from app.setup import bot, config
 from app.utils import is_dm, is_mod, try_dm
 
@@ -64,6 +65,9 @@ async def on_message(message: discord.Message) -> None:
     # Look for issue/PR/discussion mentions and name/link them
     if ENTITY_REGEX.search(message.content):
         await reply_with_entities(message)
+
+    # Check for Zig code blocks and format them
+    await check_for_zig_code(message)
 
 
 async def sync(bot: commands.Bot, message: discord.Message) -> None:

--- a/app/core.py
+++ b/app/core.py
@@ -10,6 +10,7 @@ from app.components.autoclose import autoclose_solved_posts
 from app.components.docs import refresh_sitemap
 from app.components.entity_mentions import (
     ENTITY_REGEX,
+    entity_mention_delete_handler,
     entity_mention_edit_handler,
     load_emojis,
     reply_with_entities,
@@ -75,6 +76,11 @@ async def on_message(message: discord.Message) -> None:
 async def on_message_edit(before: discord.Message, after: discord.Message) -> None:
     await entity_mention_edit_handler(before, after)
     await zig_codeblock_edit_handler(before, after)
+
+
+@bot.event
+async def on_message_delete(message: discord.Message) -> None:
+    await entity_mention_delete_handler(message)
 
 
 async def sync(bot: commands.Bot, message: discord.Message) -> None:

--- a/app/core.py
+++ b/app/core.py
@@ -16,7 +16,11 @@ from app.components.entity_mentions import (
     reply_with_entities,
 )
 from app.components.message_filter import check_message_filters
-from app.components.zig_codeblocks import check_for_zig_code, zig_codeblock_edit_handler
+from app.components.zig_codeblocks import (
+    check_for_zig_code,
+    zig_codeblock_delete_handler,
+    zig_codeblock_edit_handler,
+)
 from app.setup import bot, config
 from app.utils import is_dm, is_mod, try_dm
 
@@ -81,6 +85,7 @@ async def on_message_edit(before: discord.Message, after: discord.Message) -> No
 @bot.event
 async def on_message_delete(message: discord.Message) -> None:
     await entity_mention_delete_handler(message)
+    await zig_codeblock_delete_handler(message)
 
 
 async def sync(bot: commands.Bot, message: discord.Message) -> None:

--- a/app/core.py
+++ b/app/core.py
@@ -10,6 +10,7 @@ from app.components.autoclose import autoclose_solved_posts
 from app.components.docs import refresh_sitemap
 from app.components.entity_mentions import (
     ENTITY_REGEX,
+    entity_mention_edit_handler,
     load_emojis,
     reply_with_entities,
 )
@@ -68,6 +69,11 @@ async def on_message(message: discord.Message) -> None:
 
     # Check for Zig code blocks and format them
     await check_for_zig_code(message)
+
+
+@bot.event
+async def on_message_edit(before: discord.Message, after: discord.Message) -> None:
+    await entity_mention_edit_handler(before, after)
 
 
 async def sync(bot: commands.Bot, message: discord.Message) -> None:

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 import io
+from contextlib import suppress
 from textwrap import shorten
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -185,3 +187,11 @@ async def check_message(
     if (original_msg := await _get_original_message(msg)) is None:
         return False
     return await check_message(original_msg, predicate)
+
+
+async def remove_view_after_timeout(
+    message: discord.Message, timeout: float = 30.0
+) -> None:
+    await asyncio.sleep(timeout)
+    with suppress(discord.NotFound, discord.HTTPException):
+        await message.edit(view=None)

--- a/app/utils.py
+++ b/app/utils.py
@@ -190,7 +190,8 @@ async def check_message(
 
 
 async def remove_view_after_timeout(
-    message: discord.Message, timeout: float = 30.0
+    message: discord.Message,
+    timeout: float = 30.0,  # noqa: ASYNC109
 ) -> None:
     await asyncio.sleep(timeout)
     with suppress(discord.NotFound, discord.HTTPException):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,15 +26,16 @@ target-version = "py312"
 select = ["ALL"]
 ignore = [
     "COM",
+    "ERA",
     "D",
     "FIX",
+    "S",
     "ANN401",
     "ISC001",
     "T201",
     "TD003",
     "PLR2004",
-    "S",
 ]
 mccabe.max-complexity = 20
-pylint.max-branches = 15
+pylint.max-branches = 20
 pylint.max-returns = 15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "githubkit~=0.12.4",
     "python-dotenv==1.0.1",
     "sentry-sdk>=2.3.1,<3",
+    "zig-codeblocks==0.2.3",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -218,6 +218,7 @@ dependencies = [
     { name = "githubkit" },
     { name = "python-dotenv" },
     { name = "sentry-sdk" },
+    { name = "zig-codeblocks" },
 ]
 
 [package.dev-dependencies]
@@ -231,6 +232,7 @@ requires-dist = [
     { name = "githubkit", specifier = "~=0.12.4" },
     { name = "python-dotenv", specifier = "==1.0.1" },
     { name = "sentry-sdk", specifier = ">=2.3.1,<3" },
+    { name = "zig-codeblocks", specifier = "==0.2.3" },
 ]
 
 [package.metadata.requires-dev]
@@ -308,6 +310,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442 },
+]
+
+[[package]]
+name = "more-itertools"
+version = "10.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/3b/7fa1fe835e2e93fd6d7b52b2f95ae810cf5ba133e1845f726f5a992d62c2/more-itertools-10.6.0.tar.gz", hash = "sha256:2cd7fad1009c31cc9fb6a035108509e6547547a7a738374f10bd49a09eb3ee3b", size = 125009 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/62/0fe302c6d1be1c777cab0616e6302478251dfbf9055ad426f5d0def75c89/more_itertools-10.6.0-py3-none-any.whl", hash = "sha256:6eb054cb4b6db1473f6e15fcc676a08e4732548acd47c708f0e179c2c7c01e89", size = 63038 },
 ]
 
 [[package]]
@@ -500,6 +511,43 @@ wheels = [
 ]
 
 [[package]]
+name = "tree-sitter"
+version = "0.24.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/a2/698b9d31d08ad5558f8bfbfe3a0781bd4b1f284e89bde3ad18e05101a892/tree-sitter-0.24.0.tar.gz", hash = "sha256:abd95af65ca2f4f7eca356343391ed669e764f37748b5352946f00f7fc78e734", size = 168304 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/57/3a590f287b5aa60c07d5545953912be3d252481bf5e178f750db75572bff/tree_sitter-0.24.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:14beeff5f11e223c37be7d5d119819880601a80d0399abe8c738ae2288804afc", size = 140788 },
+    { url = "https://files.pythonhosted.org/packages/61/0b/fc289e0cba7dbe77c6655a4dd949cd23c663fd62a8b4d8f02f97e28d7fe5/tree_sitter-0.24.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:26a5b130f70d5925d67b47db314da209063664585a2fd36fa69e0717738efaf4", size = 133945 },
+    { url = "https://files.pythonhosted.org/packages/86/d7/80767238308a137e0b5b5c947aa243e3c1e3e430e6d0d5ae94b9a9ffd1a2/tree_sitter-0.24.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5fc5c3c26d83c9d0ecb4fc4304fba35f034b7761d35286b936c1db1217558b4e", size = 564819 },
+    { url = "https://files.pythonhosted.org/packages/bf/b3/6c5574f4b937b836601f5fb556b24804b0a6341f2eb42f40c0e6464339f4/tree_sitter-0.24.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:772e1bd8c0931c866b848d0369b32218ac97c24b04790ec4b0e409901945dd8e", size = 579303 },
+    { url = "https://files.pythonhosted.org/packages/0a/f4/bd0ddf9abe242ea67cca18a64810f8af230fc1ea74b28bb702e838ccd874/tree_sitter-0.24.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:24a8dd03b0d6b8812425f3b84d2f4763322684e38baf74e5bb766128b5633dc7", size = 581054 },
+    { url = "https://files.pythonhosted.org/packages/8c/1c/ff23fa4931b6ef1bbeac461b904ca7e49eaec7e7e5398584e3eef836ec96/tree_sitter-0.24.0-cp312-cp312-win_amd64.whl", hash = "sha256:f9e8b1605ab60ed43803100f067eed71b0b0e6c1fb9860a262727dbfbbb74751", size = 120221 },
+    { url = "https://files.pythonhosted.org/packages/b2/2a/9979c626f303177b7612a802237d0533155bf1e425ff6f73cc40f25453e2/tree_sitter-0.24.0-cp312-cp312-win_arm64.whl", hash = "sha256:f733a83d8355fc95561582b66bbea92ffd365c5d7a665bc9ebd25e049c2b2abb", size = 108234 },
+    { url = "https://files.pythonhosted.org/packages/61/cd/2348339c85803330ce38cee1c6cbbfa78a656b34ff58606ebaf5c9e83bd0/tree_sitter-0.24.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0d4a6416ed421c4210f0ca405a4834d5ccfbb8ad6692d4d74f7773ef68f92071", size = 140781 },
+    { url = "https://files.pythonhosted.org/packages/8b/a3/1ea9d8b64e8dcfcc0051028a9c84a630301290995cd6e947bf88267ef7b1/tree_sitter-0.24.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e0992d483677e71d5c5d37f30dfb2e3afec2f932a9c53eec4fca13869b788c6c", size = 133928 },
+    { url = "https://files.pythonhosted.org/packages/fe/ae/55c1055609c9428a4aedf4b164400ab9adb0b1bf1538b51f4b3748a6c983/tree_sitter-0.24.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57277a12fbcefb1c8b206186068d456c600dbfbc3fd6c76968ee22614c5cd5ad", size = 564497 },
+    { url = "https://files.pythonhosted.org/packages/ce/d0/f2ffcd04882c5aa28d205a787353130cbf84b2b8a977fd211bdc3b399ae3/tree_sitter-0.24.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d25fa22766d63f73716c6fec1a31ee5cf904aa429484256bd5fdf5259051ed74", size = 578917 },
+    { url = "https://files.pythonhosted.org/packages/af/82/aebe78ea23a2b3a79324993d4915f3093ad1af43d7c2208ee90be9273273/tree_sitter-0.24.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7d5d9537507e1c8c5fa9935b34f320bfec4114d675e028f3ad94f11cf9db37b9", size = 581148 },
+    { url = "https://files.pythonhosted.org/packages/a1/b4/6b0291a590c2b0417cfdb64ccb8ea242f270a46ed429c641fbc2bfab77e0/tree_sitter-0.24.0-cp313-cp313-win_amd64.whl", hash = "sha256:f58bb4956917715ec4d5a28681829a8dad5c342cafd4aea269f9132a83ca9b34", size = 120207 },
+    { url = "https://files.pythonhosted.org/packages/a8/18/542fd844b75272630229c9939b03f7db232c71a9d82aadc59c596319ea6a/tree_sitter-0.24.0-cp313-cp313-win_arm64.whl", hash = "sha256:23641bd25dcd4bb0b6fa91b8fb3f46cc9f1c9f475efe4d536d3f1f688d1b84c8", size = 108232 },
+]
+
+[[package]]
+name = "tree-sitter-zig"
+version = "1.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/97/75967b81460e0ce999de4736b9ac189dcd5ad1c85aabcc398ba529f4838e/tree_sitter_zig-1.1.2.tar.gz", hash = "sha256:da24db16df92f7fcfa34448e06a14b637b1ff985f7ce2ee19183c489e187a92e", size = 194084 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/c6/db41d3f6c7c0174db56d9122a2a4d8b345c377ca87268e76557b2879675e/tree_sitter_zig-1.1.2-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:e7542354a5edba377b5692b2add4f346501306d455e192974b7e76bf1a61a282", size = 61900 },
+    { url = "https://files.pythonhosted.org/packages/5a/78/93d32fea98b3b031bc0fbec44e27f2b8cc1a1a8ff5a99dfb1a8f85b11d43/tree_sitter_zig-1.1.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:daa2cdd7c1a2d278f2a917c85993adb6e84d37778bfc350ee9e342872e7f8be2", size = 67837 },
+    { url = "https://files.pythonhosted.org/packages/40/45/ef5afd6b79bd58731dae2cf61ff7960dd616737397db4d2e926457ff24b7/tree_sitter_zig-1.1.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1962e95067ac5ee784daddd573f828ef32f15e9c871967df6833d3d389113eae", size = 83391 },
+    { url = "https://files.pythonhosted.org/packages/78/02/275523eb05108d83e154f52c7255763bac8b588ae14163563e19479322a7/tree_sitter_zig-1.1.2-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e924509dcac5a6054da357e3d6bcf37ea82984ee1d2a376569753d32f61ea8bb", size = 82323 },
+    { url = "https://files.pythonhosted.org/packages/ef/e9/ff3c11097e37d4d899155c8fbdf7531063b6d15ee252b2e01ce0063f0218/tree_sitter_zig-1.1.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:d8f463c370cdd71025b8d40f90e21e8fc25c7394eb64ebd53b1e566d712a3a68", size = 81383 },
+    { url = "https://files.pythonhosted.org/packages/ab/5c/f5fb2ce355bbd381e647b04e8b2078a4043e663b6df6145d87550d3c3fe5/tree_sitter_zig-1.1.2-cp39-abi3-win_amd64.whl", hash = "sha256:7b94f00a0e69231ac4ebf0aa763734b9b5637e0ff13634ebfe6d13fadece71e9", size = 65105 },
+    { url = "https://files.pythonhosted.org/packages/34/8d/c0a481cc7bba9d39c533dd3098463854b5d3c4e6134496d9d83cd1331e51/tree_sitter_zig-1.1.2-cp39-abi3-win_arm64.whl", hash = "sha256:88152ebeaeca1431a6fc943a8b391fee6f6a8058f17435015135157735061ddf", size = 63219 },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.12.2"
 source = { registry = "https://pypi.org/simple" }
@@ -561,4 +609,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/b7/4b3c7c7913a278d445cc6284e59b2e62fa25e72758f888b7a7a39eb8423f/yarl-1.18.3-cp313-cp313-win32.whl", hash = "sha256:61ee62ead9b68b9123ec24bc866cbef297dd266175d53296e2db5e7f797f902d", size = 310152 },
     { url = "https://files.pythonhosted.org/packages/f5/d5/688db678e987c3e0fb17867970700b92603cadf36c56e5fb08f23e822a0c/yarl-1.18.3-cp313-cp313-win_amd64.whl", hash = "sha256:578e281c393af575879990861823ef19d66e2b1d0098414855dd367e234f5b3c", size = 315723 },
     { url = "https://files.pythonhosted.org/packages/f5/4b/a06e0ec3d155924f77835ed2d167ebd3b211a7b0853da1cf8d8414d784ef/yarl-1.18.3-py3-none-any.whl", hash = "sha256:b57f4f58099328dfb26c6a771d09fb20dbbae81d20cfb66141251ea063bd101b", size = 45109 },
+]
+
+[[package]]
+name = "zig-codeblocks"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+    { name = "tree-sitter" },
+    { name = "tree-sitter-zig" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/95/99e6fbeae363cd75b5df338682f69e96095f4c1b3a6f03cb996c834a01be/zig_codeblocks-0.2.3.tar.gz", hash = "sha256:80ed4bd06f6921ce89d8f79e0cc082c78f2be3e8b7bacebd09b4271b795158c3", size = 530548 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/ef/6fadbdb24b6ab8480b6a868091fd83c186457ff6cf8c8f9fb34f371a770d/zig_codeblocks-0.2.3-py3-none-any.whl", hash = "sha256:7700694ed9deb8e0d76519a776aff5663ecb4474bedac359409896c1fb1211bd", size = 8506 },
 ]


### PR DESCRIPTION
Closes #137. This relies on my https://github.com/trag1c/zig-codeblocks project.

Still left to do:
- [x] **Highlighting**
  - [x] Stabilize the core mechanism → https://github.com/trag1c/zig-codeblocks/issues/1
  - [x] https://github.com/trag1c/zig-codeblocks/issues/3 so adjustments can be done in this repo
  - [x] Fix https://github.com/trag1c/zig-codeblocks/issues/5
- [x] **Discord**
  - [x] Split into multiple messages when too large
  - [x] React to edits/deletions
  - [x] Add an option to freeze the message (so it stops reacting)
  - [x] Add a "Replace my message" option (with a confirmation prompt)
  - [x] **Files**
    - [x] Highlight files too
    - [x] Send small files back as regular code blocks
    - [x] Simplify attachment processing → https://github.com/trag1c/zig-codeblocks/issues/6
- [x] ~~Fix the Nix build fail (@Uzaaft's on it)~~ Nix is no more (#161)