### PR TITLE
Handle long help post titles gracefully

### DIFF
--- a/app/components/close_help_post.py
+++ b/app/components/close_help_post.py
@@ -189,10 +189,8 @@ async def close_post(
 
         delim = ";" if ":" in title_prefix else ":"
         title_prefix = title_prefix.strip("[]").lower()
-        if additional_reply:
-            additional_reply = f"Closed{delim} {title_prefix}.\n{additional_reply}"
-        else:
-            additional_reply = f"Closed{delim} {title_prefix}."
+        additional_reply = f"\n{additional_reply}" if additional_reply else ""
+        additional_reply = f"Closed{delim} {title_prefix}.{additional_reply}"
 
     if additional_reply:
         await post.send(additional_reply)

--- a/app/components/close_help_post.py
+++ b/app/components/close_help_post.py
@@ -167,7 +167,7 @@ async def close_post(
         delim = ";" if ":" in title_prefix else ":"
         title_prefix = title_prefix.strip("[]").lower()
         additional_reply = f"\n{additional_reply}" if additional_reply else ""
-        additional_reply = f"Closed{delim} {title_prefix}.{additional_reply}"
+        additional_reply = f"**Closed{delim} {title_prefix}**.{additional_reply}"
 
     if additional_reply:
         await post.send(additional_reply)

--- a/app/components/close_help_post.py
+++ b/app/components/close_help_post.py
@@ -165,10 +165,10 @@ async def close_post(
             # }
             # This tries to make as few assumptions of the keys of the
             # dictionary as possible, as the field is private.
-            returned_error = next(iter(next(iter(e._errors.values())).values()))[0][
+            returned_error = next(iter(next(iter(e._errors.values())).values()))[0][  # noqa: SLF001
                 "message"
             ]
-        except Exception:
+        except (StopIteration, IndexError):
             try:
                 # Parsing something of the form:
                 # "Invalid Form Body\nIn name: Must be 100 or fewer in length."

--- a/app/components/close_help_post.py
+++ b/app/components/close_help_post.py
@@ -187,6 +187,13 @@ async def close_post(
             returned_error = returned_error.replace("must be", "must have been")
             followup = f"Unable to change the post title as it {returned_error}"
 
+        delim = ";" if ":" in title_prefix else ":"
+        title_prefix = title_prefix.removeprefix("[").removesuffix("]").lower()
+        if additional_reply:
+            additional_reply = f"Closed{delim} {title_prefix}.\n{additional_reply}"
+        else:
+            additional_reply = f"Closed{delim} {title_prefix}."
+
     if additional_reply:
         await post.send(additional_reply)
 

--- a/app/components/close_help_post.py
+++ b/app/components/close_help_post.py
@@ -128,7 +128,6 @@ async def close_post(
         return
 
     await interaction.response.defer(ephemeral=True)
-    followup = "Post closed."
 
     desired_tag_id = config.HELP_CHANNEL_TAG_IDS[tag]
     await post.add_tags(next(tag for tag in help_tags if tag.id == desired_tag_id))
@@ -138,6 +137,7 @@ async def close_post(
 
     try:
         await post.edit(name=f"{title_prefix} {post.name}")
+        followup = "Post closed."
     except discord.HTTPException as e:
         # Re-raise if it's not because the new post title was invalid.
         if e.status != INVALID_REQUEST_DATA or e.code != INVALID_FORM_BODY:

--- a/app/components/close_help_post.py
+++ b/app/components/close_help_post.py
@@ -188,7 +188,7 @@ async def close_post(
             followup = f"Unable to change the post title as it {returned_error}"
 
         delim = ";" if ":" in title_prefix else ":"
-        title_prefix = title_prefix.removeprefix("[").removesuffix("]").lower()
+        title_prefix = title_prefix.strip("[]").lower()
         if additional_reply:
             additional_reply = f"Closed{delim} {title_prefix}.\n{additional_reply}"
         else:


### PR DESCRIPTION
Continuation of #151, thank you GitHub.

Before this change, if the new title was longer than 100 characters, an exception would be raised.

This is *very* hacky and probably the worst code I've ever PR'd.  Perhaps "Unable to change the post title." should be returned without all that effort to show the error from the Discord API; I can change the PR to do so if requested, though I would prefer to have the nicer message so the user of the command actually knows what happened.