### PR TITLE
Add an activity status

### DIFF
--- a/app/core.py
+++ b/app/core.py
@@ -34,10 +34,19 @@ from app.utils import is_dm, is_mod, try_dm
 @bot.event
 async def on_ready() -> None:
     await load_emojis()
+
     if not autoclose_solved_posts.is_running():
         autoclose_solved_posts.start()
+
     bot_status.last_login_time = dt.datetime.now(tz=dt.UTC)
+
     print(f"Bot logged on as {bot.user}!")
+
+    await bot.change_presence(
+        activity=discord.Activity(
+            name="over the Ghostty server 👻", type=discord.ActivityType.watching
+        )
+    )
 
 
 @bot.event


### PR DESCRIPTION
It only takes so long for a bike shed to be flooded with string (that is, I expect the exact string to be bikeshed).

Some other ideas:
- “Competing in **moderation with GearBot**”
- “Playing **Ghostty 👻**” (ghost emoji optional)

I tried setting the timestamp to when the bot started up, but for some reason Discord did not like it and it didn't show up anywhere.

Edit: quick note, if your suggestion starts with `Playing`, `Streaming`, `Listening to`, `Watching` or `Competing in`, it'll can be a special status, otherwise it'll just be the average custom status that shows up in a thought bubble on the profile.