### PR TITLE
Add an activity status

### DIFF
--- a/app/components/__init__.py
+++ b/app/components/__init__.py
@@ -1,5 +1,6 @@
 from . import (
     accept_invite,
+    activity_status,
     autoclose,
     close_help_post,
     docs,
@@ -12,6 +13,7 @@ from . import (
 
 __all__ = (
     "accept_invite",
+    "activity_status",
     "autoclose",
     "close_help_post",
     "docs",

--- a/app/components/activity_status.py
+++ b/app/components/activity_status.py
@@ -1,0 +1,21 @@
+import secrets
+
+from discord import Activity, ActivityType, CustomActivity
+from discord.ext import tasks
+
+from app.setup import bot
+
+STATUSES = (
+    Activity(type=ActivityType.watching, name="over the Ghostty server 👻"),
+    CustomActivity(name="Haunting your threads 🧵"),
+    Activity(type=ActivityType.watching, name="posts in #showcase"),
+    Activity(type=ActivityType.watching, name="over #help"),
+    Activity(type=ActivityType.listening, name="your complaints"),
+    Activity(type=ActivityType.playing, name="with my config file"),
+    Activity(type=ActivityType.competing, name="the terminal game"),
+)
+
+
+@tasks.loop(hours=2)
+async def randomize_activity_status() -> None:
+    await bot.change_presence(activity=secrets.choice(STATUSES))

--- a/app/core.py
+++ b/app/core.py
@@ -8,6 +8,7 @@ import discord
 from discord.ext import commands
 from sentry_sdk import capture_exception
 
+from app.components.activity_status import randomize_activity_status
 from app.components.autoclose import autoclose_solved_posts
 from app.components.docs import refresh_sitemap
 from app.components.entity_mentions import (
@@ -36,6 +37,8 @@ async def on_ready() -> None:
     await load_emojis()
     if not autoclose_solved_posts.is_running():
         autoclose_solved_posts.start()
+    if not randomize_activity_status.is_running():
+        randomize_activity_status.start()
     bot_status.last_login_time = dt.datetime.now(tz=dt.UTC)
     print(f"Bot logged on as {bot.user}!")
 


### PR DESCRIPTION
Continuation of #173, thanks as usual GitHub 🙄.

It only takes so long for a bike shed to be flooded with string (that is, I expect the exact string to be bikeshed).

I tried setting the timestamp to when the bot started up, but for some reason Discord did not like it and it didn't show up anywhere.

Edit: quick note, if your suggestion starts with `Playing`, `Streaming`, `Listening to`, `Watching` or `Competing in`, it'll can be a special status, otherwise it'll just be the average custom status that shows up in a thought bubble on the profile.