### PR TITLE
Small changes to TTRCache

### DIFF
--- a/app/components/entity_mentions/cache.py
+++ b/app/components/entity_mentions/cache.py
@@ -1,46 +1,11 @@
-import datetime as dt
-from abc import ABC, abstractmethod
-
 from githubkit.exception import RequestFailed
 
 from .discussions import get_discussion
 from .models import Entity, Issue, PullRequest
 from app.setup import gh
+from app.utils import TTRCache
 
 type CacheKey = tuple[str, str, int]
-
-
-class TTRCache[KT, VT](ABC):
-    def __init__(self, **ttr: int | float) -> None:
-        """Keyword arguments are passed to datetime.timedelta."""
-        self._ttr = dt.timedelta(**ttr)
-        self._cache: dict[KT, tuple[dt.datetime, VT]] = {}
-
-    def __contains__(self, key: KT) -> bool:
-        return key in self._cache
-
-    def __getitem__(self, key: KT) -> tuple[dt.datetime, VT]:
-        return self._cache[key]
-
-    def __setitem__(self, key: KT, value: VT) -> None:
-        self._cache[key] = (dt.datetime.now(tz=dt.UTC), value)
-
-    @abstractmethod
-    async def fetch(self, key: KT) -> None:
-        pass
-
-    async def _refresh(self, key: KT) -> None:
-        if key not in self:
-            await self.fetch(key)
-            return
-        timestamp, *_ = self[key]
-        if dt.datetime.now(tz=dt.UTC) - timestamp >= self._ttr:
-            await self.fetch(key)
-
-    async def get(self, key: KT) -> VT:
-        await self._refresh(key)
-        _, value = self[key]
-        return value
 
 
 class EntityCache(TTRCache[CacheKey, Entity]):

--- a/app/components/entity_mentions/cache.py
+++ b/app/components/entity_mentions/cache.py
@@ -11,8 +11,9 @@ type CacheKey = tuple[str, str, int]
 
 
 class TTRCache[KT, VT](ABC):
-    def __init__(self, ttr: int) -> None:
-        self._ttr = dt.timedelta(seconds=ttr)
+    def __init__(self, **ttr: int | float) -> None:
+        """Keyword arguments are passed to datetime.timedelta."""
+        self._ttr = dt.timedelta(**ttr)
         self._cache: dict[KT, tuple[dt.datetime, VT]] = {}
 
     def __contains__(self, key: KT) -> bool:
@@ -55,4 +56,4 @@ class EntityCache(TTRCache[CacheKey, Entity]):
             self[key] = await get_discussion(*key)
 
 
-entity_cache = EntityCache(1800)  # 30 minutes
+entity_cache = EntityCache(minutes=30)

--- a/app/components/entity_mentions/code_links.py
+++ b/app/components/entity_mentions/code_links.py
@@ -50,7 +50,7 @@ class ContentCache(TTRCache[SnippetPath, str]):
         self[key] = resp.text
 
 
-content_cache = ContentCache(1800)  # 30 minutes
+content_cache = ContentCache(minutes=30)
 code_linker = MessageLinker()
 
 

--- a/app/components/entity_mentions/code_links.py
+++ b/app/components/entity_mentions/code_links.py
@@ -6,12 +6,12 @@ from typing import NamedTuple
 import discord
 from zig_codeblocks import highlight_zig_code
 
-from .cache import TTRCache
 from app.components.zig_codeblocks import THEME
 from app.setup import gh
 from app.utils import (
     DeleteMessage,
     MessageLinker,
+    TTRCache,
     create_delete_hook,
     create_edit_hook,
     remove_view_after_timeout,

--- a/app/components/entity_mentions/comments/fetching.py
+++ b/app/components/entity_mentions/comments/fetching.py
@@ -62,7 +62,7 @@ class CommentCache(TTRCache[tuple[EntityGist, str, int], Comment]):
             self[key] = await coro(entity_gist, event_no)
 
 
-comment_cache = CommentCache(1800)  # 30 minutes
+comment_cache = CommentCache(minutes=30)
 
 
 def _make_author(user: BaseModel | None) -> GitHubUser:

--- a/app/components/entity_mentions/comments/fetching.py
+++ b/app/components/entity_mentions/comments/fetching.py
@@ -9,10 +9,11 @@ from typing import TYPE_CHECKING, cast
 from githubkit.exception import RequestFailed
 from zig_codeblocks import extract_codeblocks
 
-from app.components.entity_mentions.cache import TTRCache, entity_cache
+from app.components.entity_mentions.cache import entity_cache
 from app.components.entity_mentions.discussions import get_discussion_comment
 from app.components.entity_mentions.models import Comment, EntityGist, GitHubUser
 from app.setup import gh
+from app.utils import TTRCache
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator

--- a/app/components/entity_mentions/resolution.py
+++ b/app/components/entity_mentions/resolution.py
@@ -20,7 +20,7 @@ class OwnerCache(TTRCache[str, str]):
         self[key] = await find_repo_owner(key)
 
 
-owner_cache = OwnerCache(3600)  # 1 hour
+owner_cache = OwnerCache(hours=1)
 
 
 async def find_repo_owner(name: str) -> str:

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 import discord
 
+from .cache import TTRCache
 from .hooks import (
     MessageLinker,
     create_delete_hook,
@@ -29,6 +30,7 @@ __all__ = (
     "GuildTextChannel",
     "MessageData",
     "MessageLinker",
+    "TTRCache",
     "create_delete_hook",
     "create_edit_hook",
     "dynamic_timestamp",

--- a/app/utils/cache.py
+++ b/app/utils/cache.py
@@ -1,0 +1,35 @@
+import datetime as dt
+from abc import ABC, abstractmethod
+
+
+class TTRCache[KT, VT](ABC):
+    def __init__(self, **ttr: float) -> None:
+        """Keyword arguments are passed to datetime.timedelta."""
+        self._ttr = dt.timedelta(**ttr)
+        self._cache: dict[KT, tuple[dt.datetime, VT]] = {}
+
+    def __contains__(self, key: KT) -> bool:
+        return key in self._cache
+
+    def __getitem__(self, key: KT) -> tuple[dt.datetime, VT]:
+        return self._cache[key]
+
+    def __setitem__(self, key: KT, value: VT) -> None:
+        self._cache[key] = (dt.datetime.now(tz=dt.UTC), value)
+
+    @abstractmethod
+    async def fetch(self, key: KT) -> None:
+        pass
+
+    async def _refresh(self, key: KT) -> None:
+        if key not in self:
+            await self.fetch(key)
+            return
+        timestamp, *_ = self[key]
+        if dt.datetime.now(tz=dt.UTC) - timestamp >= self._ttr:
+            await self.fetch(key)
+
+    async def get(self, key: KT) -> VT:
+        await self._refresh(key)
+        _, value = self[key]
+        return value


### PR DESCRIPTION
1. Made the TTRCache splat its arguments to timedelta.
2. Moved it to `utils/` as I expect it would be useful outside of `entity_mentions` too (e.g., for #183).

I recommend viewing every commit individually, as it makes it more clear what changed than if you only look at the final diff.