### PR TITLE
Lock old posts to discourage necroposting

### DIFF
--- a/app/components/lock_old_posts.py
+++ b/app/components/lock_old_posts.py
@@ -5,7 +5,7 @@ import datetime as dt
 import discord
 
 from app import config
-from app.utils import dynamic_timestamp, post_is_solved
+from app.utils import aenumerate, dynamic_timestamp, post_is_solved
 
 
 async def check_for_old_posts(message: discord.Message) -> None:
@@ -21,20 +21,19 @@ async def check_for_old_posts(message: discord.Message) -> None:
     ):
         return
 
-    try:
-        # Ignore messages less than a minute old for the same person may have
-        # sent multiple in quick succession, resulting in their own message
-        # being considered as activity.
-        last = await _get_message(post, 1, before=now - dt.timedelta(minutes=1))
-    except IndexError:
-        # There were no messages older than one minute. Assuming the threshold
-        # below stays at a reasonably large limit, this either means that every
-        # message was deleted, or that there was no response and the original
-        # poster deleted the starter message. It's very unlikely for the post
-        # to no longer be relevant; nor is it likely that anyone would even
-        # message in such a thread. Thus, silently exit if this is the case.
-        return
-    if last.created_at > now - dt.timedelta(days=30):
+    # Ignore messages less than a minute old for the same person may have
+    # sent multiple in quick succession, resulting in their own message
+    # being considered as activity.
+    last = await _get_message(post, 1, before=now - dt.timedelta(minutes=1))
+    # Don't lock the post if it isn't old enough.
+    if last is None or last.created_at > now - dt.timedelta(days=30):
+        # If last was None, there were no messages older than one minute.
+        # Assuming the threshold above stays at a reasonably large limit, this
+        # either means that every message was deleted, or that there was no
+        # response and the original poster deleted the starter message. It's
+        # very unlikely for the post to no longer be relevant; nor is it likely
+        # that anyone would even message in such a thread. Thus, silently exit
+        # if this is the case.
         return
 
     try:
@@ -57,8 +56,6 @@ async def _get_message(
     *,
     before: discord.abc.SnowflakeTime | None = None,
     around: discord.abc.SnowflakeTime | None = None,
-) -> discord.Message:
-    return [
-        message
-        async for message in thread.history(limit=n + 1, before=before, around=around)
-    ][n]
+) -> discord.Message | None:
+    messages = thread.history(limit=n + 1, before=before, around=around)
+    return await anext((m async for i, m in aenumerate(messages) if i == n), None)

--- a/app/components/lock_old_posts.py
+++ b/app/components/lock_old_posts.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import datetime as dt
+
+import discord
+
+from app import config
+from app.utils import dynamic_timestamp, post_is_solved
+
+
+async def check_for_old_posts(message: discord.Message) -> None:
+    post = message.channel
+    now = dt.datetime.now(tz=dt.UTC)
+    if (
+        not isinstance(post, discord.Thread)
+        or not post.parent
+        or post.parent.id != config.HELP_CHANNEL_ID
+        or post.locked
+        or post.last_message_id is None
+        or not post_is_solved(post)
+    ):
+        return
+
+    try:
+        # Ignore messages less than a minute old for the same person may have
+        # sent multiple in quick succession, resulting in their own message
+        # being considered as activity.
+        last = await _get_message(post, 1, before=now - dt.timedelta(minutes=1))
+    except IndexError:
+        # There were no messages older than one minute. Assuming the threshold
+        # below stays at a reasonably large limit, this either means that every
+        # message was deleted, or that there was no response and the original
+        # poster deleted the starter message. It's very unlikely for the post
+        # to no longer be relevant; nor is it likely that anyone would even
+        # message in such a thread. Thus, silently exit if this is the case.
+        return
+    if last.created_at > now - dt.timedelta(days=30):
+        return
+
+    try:
+        creation_time_ago = dynamic_timestamp(
+            (await post.fetch_message(post.id)).created_at, "R"
+        )
+    except discord.NotFound:
+        creation_time_ago = "over a month ago"
+    await message.reply(
+        f"This post was created {creation_time_ago} and is likely no longer "
+        "relevant. Please open a new thread instead, making sure to provide "
+        "the required information."
+    )
+    await post.edit(locked=True)
+
+
+async def _get_message(
+    thread: discord.Thread,
+    n: int,
+    *,
+    before: discord.abc.SnowflakeTime | None = None,
+    around: discord.abc.SnowflakeTime | None = None,
+) -> discord.Message:
+    return [
+        message
+        async for message in thread.history(limit=n + 1, before=before, around=around)
+    ][n]

--- a/app/core.py
+++ b/app/core.py
@@ -24,6 +24,7 @@ from app.components.entity_mentions import (
     reply_with_comments,
     reply_with_entities,
 )
+from app.components.lock_old_posts import check_for_old_posts
 from app.components.message_filter import check_message_filters
 from app.components.status import bot_status, report_status
 from app.components.zig_codeblocks import (
@@ -90,6 +91,7 @@ async def on_message(message: discord.Message) -> None:
         check_for_zig_code(message),  # Check for Zig code blocks and format them
         reply_with_code(message),  # Look for GitHub code links and reply with contents
         reply_with_comments(message),  # Check for entity comments and reply with embeds
+        check_for_old_posts(message),  # Check for bumps of old help posts and lock them
     ]
 
     # Look for issue/PR/discussion mentions and name/link them

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -119,6 +119,17 @@ async def try_dm(account: Account, content: str, **extras: Any) -> None:
         print(f"Failed to DM {account} with: {shorten(content, width=50)}")
 
 
+def post_has_tag(post: discord.Thread, substring: str) -> bool:
+    return any(substring in tag.name.casefold() for tag in post.applied_tags)
+
+
+def post_is_solved(post: discord.Thread) -> bool:
+    return any(
+        post_has_tag(post, tag)
+        for tag in ("solved", "moved to github", "duplicate", "stale")
+    )
+
+
 def escape_special(content: str) -> str:
     """
     Escape all text that Discord considers to be special.

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -56,6 +56,8 @@ __all__ = (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
     from typing_extensions import TypeIs
 
 
@@ -128,6 +130,15 @@ def post_is_solved(post: discord.Thread) -> bool:
         post_has_tag(post, tag)
         for tag in ("solved", "moved to github", "duplicate", "stale")
     )
+
+
+async def aenumerate[T](
+    it: AsyncIterator[T], start: int = 0
+) -> AsyncIterator[tuple[int, T]]:
+    i = start
+    async for x in it:
+        yield i, x
+        i += 1
 
 
 def escape_special(content: str) -> str:


### PR DESCRIPTION
Closes #174.

A known issue is that sending multiple messages in quick succession will trigger multiple responses, but I do not know of any clean way to work around this as the Discord API is not the fastest thing in the world, and this operation is inherently racy.

Documentation update: #197.