### PR TITLE
Use a webhook for /docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,9 @@ message option:
   <img src="https://github.com/user-attachments/assets/0938881f-80ad-44d0-8414-915324f2761e" alt="/docs command message option" height="250px">
 </p>
 
+If a message is provided, a webhook will be used to send the message under the
+interactor's server profile.
+
 ## `/close`
 
 A command group to mark help channel posts as resolved, with various options for different resolution scenarios:

--- a/app/components/docs.py
+++ b/app/components/docs.py
@@ -140,6 +140,10 @@ async def docs(
         await interaction.response.send_message("Documentation linked.", ephemeral=True)
     except ValueError as exc:
         await interaction.response.send_message(str(exc), ephemeral=True)
+    except discord.HTTPException:
+        await interaction.response.send_message(
+            "Message content too long.", ephemeral=True
+        )
 
 
 def get_docs_link(section: str, page: str) -> str:

--- a/app/components/docs.py
+++ b/app/components/docs.py
@@ -9,6 +9,7 @@ from discord.app_commands import Choice, autocomplete
 
 from app.components.status import bot_status
 from app.setup import bot, config, gh
+from app.utils import get_or_create_webhook
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -125,9 +126,18 @@ async def docs(
     interaction: discord.Interaction, section: str, page: str, message: str = ""
 ) -> None:
     try:
-        await interaction.response.send_message(
-            f"{message}\n{get_docs_link(section, page)}"
+        if not message or not isinstance(
+            interaction.channel, discord.TextChannel | discord.ForumChannel
+        ):
+            await interaction.response.send_message(get_docs_link(section, page))
+            return
+        webhook = await get_or_create_webhook("Ghostty Moderator", interaction.channel)
+        await webhook.send(
+            f"{message}\n{get_docs_link(section, page)}",
+            username=interaction.user.display_name,
+            avatar_url=interaction.user.display_avatar.url,
         )
+        await interaction.response.send_message("Documentation linked.", ephemeral=True)
     except ValueError as exc:
         await interaction.response.send_message(str(exc), ephemeral=True)
 


### PR DESCRIPTION
Closes #194.

Also handles messages that are too long.  This affects both the interaction[^1] and the webhook paths, but I only noticed it now and don't want to make a new PR; plus you can't get 2000 characters without specifying `message`.

[^1]: It is still possible to get the interaction response with `message` specified in some specific channel types (such as voice channels).