### PR TITLE
Avoid reacting with entity mentions on an entity comment link

### DIFF
--- a/app/components/entity_mentions/resolution.py
+++ b/app/components/entity_mentions/resolution.py
@@ -13,7 +13,7 @@ ENTITY_REGEX = re.compile(
     r"(?P<owner>\b[a-z0-9\-]+/)?"
     r"(?P<repo>\b[a-z0-9\-\._]+)?"
     r"(?P<sep>/(?:issues|pull|discussions)/|#)"
-    r"(?P<number>\d{1,6})(?!\.\d)\b",
+    r"(?P<number>\d{1,6})(?!\.\d|#)\b",
     re.IGNORECASE,
 )
 


### PR DESCRIPTION
Fixes #200.

Ironic how it's [number 200] when the issue is anything *but* okay :P.

[number 200]: https://http.cat/200