### PR TITLE
Handle Nitro reactions in moved messages

### DIFF
--- a/app/utils/message_data.py
+++ b/app/utils/message_data.py
@@ -18,7 +18,7 @@ class MessageData(NamedTuple):
     edited_at: dt.datetime | None
     attachments: list[discord.File]
     skipped_attachments: int
-    raw_reactions: list[discord.Reaction]
+    reactions: list[discord.Reaction]
 
 
 async def scrape_message_data(message: discord.Message) -> MessageData:

--- a/app/utils/message_data.py
+++ b/app/utils/message_data.py
@@ -19,7 +19,6 @@ class MessageData(NamedTuple):
     attachments: list[discord.File]
     skipped_attachments: int
     raw_reactions: list[discord.Reaction]
-    reactions: dict[str | discord.Emoji, int]
 
 
 async def scrape_message_data(message: discord.Message) -> MessageData:
@@ -30,7 +29,6 @@ async def scrape_message_data(message: discord.Message) -> MessageData:
         message.edited_at,
         *await _get_attachments(message),
         message.reactions,
-        _get_reactions(message),
     )
 
 
@@ -49,14 +47,3 @@ async def _get_attachments(message: discord.Message) -> tuple[list[discord.File]
         attachments.append(discord.File(fp, filename=attachment.filename))
 
     return attachments, skipped_attachments
-
-
-def _get_reactions(message: discord.Message) -> dict[str | discord.Emoji, int]:
-    reactions: dict[str | discord.Emoji, int] = {}
-    for reaction in message.reactions:
-        if isinstance(emoji := reaction.emoji, discord.Emoji) and not emoji.is_usable():
-            continue
-        if isinstance(emoji, discord.PartialEmoji):
-            continue
-        reactions[emoji] = reaction.count
-    return reactions

--- a/app/utils/message_data.py
+++ b/app/utils/message_data.py
@@ -18,6 +18,7 @@ class MessageData(NamedTuple):
     edited_at: dt.datetime | None
     attachments: list[discord.File]
     skipped_attachments: int
+    raw_reactions: list[discord.Reaction]
     reactions: dict[str | discord.Emoji, int]
 
 
@@ -28,6 +29,7 @@ async def scrape_message_data(message: discord.Message) -> MessageData:
         message.created_at,
         message.edited_at,
         *await _get_attachments(message),
+        message.reactions,
         _get_reactions(message),
     )
 

--- a/app/utils/webhooks.py
+++ b/app/utils/webhooks.py
@@ -297,8 +297,15 @@ def _format_subtext(
     include_timestamp: bool = True,
 ) -> str:
     lines: list[str] = []
-    if reactions := msg_data.reactions.items():
-        lines.append("   ".join(f"{emoji} x{count}" for emoji, count in reactions))
+    if reactions := msg_data.raw_reactions:
+        formatted_reactions = [
+            f"{emoji} x{reaction.count}"
+            if isinstance(emoji := reaction.emoji, str)
+            or getattr(emoji, "is_usable", lambda: False)()
+            else f"[{emoji.name}]({emoji.url}) x{reaction.count}"
+            for reaction in reactions
+        ]
+        lines.append("   ".join(formatted_reactions))
     if msg_data.created_at > dt.datetime.now(tz=dt.UTC) - dt.timedelta(hours=12):
         include_timestamp = False
     if include_timestamp:

--- a/app/utils/webhooks.py
+++ b/app/utils/webhooks.py
@@ -102,8 +102,8 @@ def _unattachable_embed(unattachable_elem: str) -> discord.Embed:
 
 def _convert_nitro_emojis(content: str, *, force: bool = False) -> str:
     """
-    Converts a custom emoji to a concealed hyperlink.  Set `force` to True
-    to convert emojis in the current guild too.
+    Convert custom emojis to concealed hyperlinks.  Set `force` to True to
+    convert emojis in the current guild too.
     """
     guild = get_ghostty_guild()
 

--- a/app/utils/webhooks.py
+++ b/app/utils/webhooks.py
@@ -115,7 +115,7 @@ def _convert_nitro_emojis(content: str, *, force: bool = False) -> str:
 
         ext = "gif" if animated else "webp"
         tag = animated and "&animated=true"
-        return f"[{name}](https://cdn.discordapp.com/emojis/{id_}.{ext}?size=48{tag}&name={name})"
+        return f"[{name}](<https://cdn.discordapp.com/emojis/{id_}.{ext}?size=48{tag}&name={name}>)"
 
     return _EMOJI_REGEX.sub(replace_nitro_emoji, content)
 
@@ -302,7 +302,7 @@ def _format_subtext(
             f"{emoji} x{reaction.count}"
             if isinstance(emoji := reaction.emoji, str)
             or getattr(emoji, "is_usable", lambda: False)()
-            else f"[{emoji.name}]({emoji.url}) x{reaction.count}"
+            else f"[{emoji.name}](<{emoji.url}>) x{reaction.count}"
             for reaction in reactions
         ]
         lines.append("   ".join(formatted_reactions))

--- a/app/utils/webhooks.py
+++ b/app/utils/webhooks.py
@@ -297,7 +297,7 @@ def _format_subtext(
     include_timestamp: bool = True,
 ) -> str:
     lines: list[str] = []
-    if reactions := msg_data.raw_reactions:
+    if reactions := msg_data.reactions:
         formatted_reactions = [
             f"{emoji} ×{reaction.count}"  # noqa: RUF001
             if isinstance(emoji := reaction.emoji, str)

--- a/app/utils/webhooks.py
+++ b/app/utils/webhooks.py
@@ -299,10 +299,10 @@ def _format_subtext(
     lines: list[str] = []
     if reactions := msg_data.raw_reactions:
         formatted_reactions = [
-            f"{emoji} x{reaction.count}"
+            f"{emoji} ×{reaction.count}"  # noqa: RUF001
             if isinstance(emoji := reaction.emoji, str)
             or getattr(emoji, "is_usable", lambda: False)()
-            else f"[{emoji.name}](<{emoji.url}>) x{reaction.count}"
+            else f"[{emoji.name}](<{emoji.url}>) ×{reaction.count}"  # noqa: RUF001
             for reaction in reactions
         ]
         lines.append("   ".join(formatted_reactions))


### PR DESCRIPTION
As well as a few other assorted half-related commits >.>; I didn't want to make an entirely new PR for them.

Here's the image for commit two:
![A screenshot of multiple moved messages containing masked links to Nitro emoji URLs that have enormous embeds attached to them.](https://github.com/user-attachments/assets/6b58ad15-47cf-424a-ac30-de52f6be3f7a)