### PR TITLE
Add hyperlinks to all relevant parts of the code links message

### DIFF
--- a/app/components/entity_mentions/code_links.py
+++ b/app/components/entity_mentions/code_links.py
@@ -89,15 +89,21 @@ async def get_snippets(content: str) -> AsyncIterator[Snippet]:
 
 
 def _format_snippet(snippet: Snippet) -> str:
+    repo_url = f"https://github.com/{snippet.repo}"
+    tree_url = f"{repo_url}/tree/{snippet.rev}"
+    file_url = f"{repo_url}/blob/{snippet.rev}/{snippet.path}"
+    line_num = snippet.range.start + 1
     range_info = (
-        f"lines {snippet.range.start + 1}–{snippet.range.stop}"  # noqa: RUF001
-        if snippet.range.stop > snippet.range.start + 1
-        else f"line {snippet.range.start + 1}"
+        f"[lines {line_num}–{snippet.range.stop}]"  # noqa: RUF001
+        f"(<{file_url}#L{line_num}-L{snippet.range.stop}>)"  # Not an en dash.
+        if snippet.range.stop > line_num
+        else f"[line {line_num}](<{file_url}#L{line_num}>)"
     )
     unquoted_path = urllib.parse.unquote(snippet.path)
     return (
-        f"`{unquoted_path}`, {range_info}"
-        f"\n-# Repo: `{snippet.repo}`, revision: `{snippet.rev}`"
+        f"[`{unquoted_path}`](<{file_url}>), {range_info}"
+        f"\n-# Repo: [`{snippet.repo}`](<{repo_url}>),"
+        f" revision: [`{snippet.rev}`](<{tree_url}>)"
         f"\n```{snippet.lang}\n{snippet.body}\n```"
     )
 


### PR DESCRIPTION
Heard you like printf-style string interpolation once, so here's an alternate diff :P /s:
<details>
<summary>Click or tap to display spoilered content.</summary>

```diff
diff --git a/app/components/entity_mentions/code_links.py b/app/components/entity_mentions/code_links.py
index 0d17340727..0db7ac3873 100644
--- a/app/components/entity_mentions/code_links.py
+++ b/app/components/entity_mentions/code_links.py
@@ -89,16 +89,42 @@
 
 
 def _format_snippet(snippet: Snippet) -> str:
-    range_info = (
-        f"lines {snippet.range.start + 1}–{snippet.range.stop}"  # noqa: RUF001
-        if snippet.range.stop > snippet.range.start + 1
-        else f"line {snippet.range.start + 1}"
-    )
-    unquoted_path = urllib.parse.unquote(snippet.path)
     return (
-        f"`{unquoted_path}`, {range_info}"
-        f"\n-# Repo: `{snippet.repo}`, revision: `{snippet.rev}`"
-        f"\n```{snippet.lang}\n{snippet.body}\n```"
+        "[`%s`](<https://github.com/%s/blob/%s/%s>), %s"
+        "\n-# Repo: [`%s`](<https://github.com/%s>),"
+        " revision: [`%s`](<https://github.com/%s/tree/%s>)\n```%s\n%s\n```"
+        % (
+            urllib.parse.unquote(snippet.path),
+            snippet.repo,
+            snippet.rev,
+            snippet.path,
+            "[lines %s–%s](<https://github.com/%s/blob/%s/%s#L%s-L%s>)"  # noqa: RUF001
+            % (
+                snippet.range.start + 1,
+                snippet.range.stop,
+                snippet.repo,
+                snippet.rev,
+                snippet.path,
+                snippet.range.start + 1,
+                snippet.range.stop,
+            )
+            if snippet.range.stop > snippet.range.start + 1
+            else "[line %s](<https://github.com/%s/blob/%s/%s#L%s>)"
+            % (
+                snippet.range.start + 1,
+                snippet.repo,
+                snippet.rev,
+                snippet.path,
+                snippet.range.start + 1,
+            ),
+            snippet.repo,
+            snippet.repo,
+            snippet.rev,
+            snippet.repo,
+            snippet.rev,
+            snippet.lang,
+            snippet.body,
+        )
     )
```

</details>