### PR TITLE
Handle character ranges in code links

### DIFF
--- a/app/components/entity_mentions/code_links.py
+++ b/app/components/entity_mentions/code_links.py
@@ -18,7 +18,8 @@ from app.utils import (
 )
 
 CODE_LINK_PATTERN = re.compile(
-    r"https?://github\.com/([^/]+)/([^/]+)/blob/([^/]+)/([^\?#]+)(?:[^\#]*)?#L(\d+)(?:-L(\d+))?"
+    r"https?://github\.com/([^/]+)/([^/]+)/blob/([^/]+)/([^\?#]+)(?:[^\#]*)?"
+    r"#L(\d+)(?:C\d+)?(?:-L(\d+)(?:C\d+)?)?"
 )
 
 


### PR DESCRIPTION
An *incredibly* easy to discover feature that totally didn't require me to assault the code viewer with a large assortment of clicks /s.

Select some text, then click on the gutter in the selected range, to get one of these URLs for testing; e.g.: select some text between lines 5 and 9, then click on the gutter on lines 5, 6, 7, 8, or 9.  If you click outside the range the selection will be deselected; annoying, I know.

A test link: https://github.com/openSUSE/fonts-config/blob/master/59-family-prefer-lang-specific-cjk.conf#L337C1-L341C45.

These are just ignored in the regular expression as it's not possible to highlight the specific characters without pulling out tree-sitter with `ansi` highlighting again.