### PR TITLE
Handle www.github.com

### DIFF
--- a/app/components/entity_mentions/code_links.py
+++ b/app/components/entity_mentions/code_links.py
@@ -18,7 +18,7 @@ from app.utils import (
 )
 
 CODE_LINK_PATTERN = re.compile(
-    r"https?://github\.com/([^/]+)/([^/]+)/blob/([^/]+)/([^\?#]+)(?:[^\#]*)?"
+    r"https?://(?:www\.)?github\.com/([^/]+)/([^/]+)/blob/([^/]+)/([^\?#]+)(?:[^\#]*)?"
     r"#L(\d+)(?:C\d+)?(?:-L(\d+)(?:C\d+)?)?"
 )
 

--- a/app/components/entity_mentions/comments/fetching.py
+++ b/app/components/entity_mentions/comments/fetching.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from pydantic import BaseModel
 
 COMMENT_PATTERN = re.compile(
-    r"https?://github\.com/([^/]+)/([^/]+)/(issues|discussions|pull)/(\d+)#(\w+?-?)(\d+)"
+    r"https?://(?:www\.)?github\.com/([^/]+)/([^/]+)/(issues|discussions|pull)/(\d+)#(\w+?-?)(\d+)"
 )
 FALLBACK_AUTHOR = GitHubUser(
     login="GitHub",

--- a/app/components/entity_mentions/resolution.py
+++ b/app/components/entity_mentions/resolution.py
@@ -9,7 +9,7 @@ from .cache import TTRCache
 from app.setup import config, gh
 
 ENTITY_REGEX = re.compile(
-    r"(?P<site>\bhttps?://github\.com/)?"
+    r"(?P<site>\bhttps?://(?:www\.)?github\.com/)?"
     r"(?P<owner>\b[a-z0-9\-]+/)?"
     r"(?P<repo>\b[a-z0-9\-\._]+)?"
     r"(?P<sep>/(?:issues|pull|discussions)/|#)"


### PR DESCRIPTION
GitHub just redirects it back to github.com, but these links *are* theoretically possible, similar to the http:// case.

Reject at one's own discretion.  This probably shouldn't be merged first since it would probably conflict with other, more important PRs.