### PR TITLE
Handle Nitro emojis in forwards

### DIFF
--- a/app/utils/webhooks.py
+++ b/app/utils/webhooks.py
@@ -112,7 +112,7 @@ def _convert_nitro_emojis(content: str, *, force: bool = False) -> str:
     def replace_nitro_emoji(match: re.Match[str]) -> str:
         animated, name, id_ = match.groups()
         emoji = bot.get_emoji(int(id_))
-        if not force and not animated and emoji and emoji.guild_id == guild.id:
+        if not force and emoji and emoji.guild_id == guild.id:
             return match[0]
 
         ext = "gif" if animated else "webp"

--- a/app/utils/webhooks.py
+++ b/app/utils/webhooks.py
@@ -207,13 +207,17 @@ async def _format_forward(
     if forward is discord.utils.MISSING:
         return [_unattachable_embed("forward")], []
 
+    content = _convert_nitro_emojis(forward.content)
+    if len(content) > 4096:
+        content = forward.content
+
     msg_data = await MessageData.scrape(forward)
     embeds = [
         *forward.embeds,
         *await asyncio.gather(*map(_get_sticker_embed, forward.stickers)),
     ]
     embed = discord.Embed(
-        description=forward.content, timestamp=forward.created_at, url=forward.jump_url
+        description=content, timestamp=forward.created_at, url=forward.jump_url
     ).set_author(name="➜ Forwarded")
 
     if hasattr(forward.channel, "name"):


### PR DESCRIPTION
I think I said I don't want to do this because then I have to make sure I don't go above the limit, but it's so easy I think I'll do it anyway.

**Before**:
![A screenshot.](https://github.com/user-attachments/assets/e39782ae-c933-4b16-8e2f-5071b095406a)
(P.S.: this was slightly fabricated since I don't actually have Nitro; this message goes above the limit and hence would remain unchanged even after this change.)

**After**:
![Another screenshot.](https://github.com/user-attachments/assets/3b4337de-ffe7-448b-a9c8-ccfd537947aa)
Which matches the output of moved messages that are not forwards.

Despite what you see above, if the emoji is from the current server, either animated or otherwise, it will be used directly:
![Yet another screenshot.](https://github.com/user-attachments/assets/9a297485-dd1b-4b99-9949-4f8f14d2981f)
The “After” screenshot doesn't display it like this because I had to make minor changes to the code to capture a screenshot for demonstration (as I don't actually have Nitro).