### PR TITLE
Attach some long code links in files

### DIFF
--- a/app/components/github_integration/code_links.py
+++ b/app/components/github_integration/code_links.py
@@ -2,6 +2,8 @@ import re
 import string
 import urllib.parse
 from collections.abc import AsyncIterator
+from io import BytesIO
+from pathlib import Path
 from typing import NamedTuple
 
 import discord
@@ -97,7 +99,7 @@ async def get_snippets(content: str) -> AsyncIterator[Snippet]:
         )
 
 
-def _format_snippet(snippet: Snippet) -> str:
+def _format_snippet(snippet: Snippet, *, include_body: bool = True) -> str:
     repo_url = f"https://github.com/{snippet.repo}"
     tree_url = f"{repo_url}/tree/{snippet.rev}"
     file_url = f"{repo_url}/blob/{snippet.rev}/{snippet.path}"
@@ -116,30 +118,38 @@ def _format_snippet(snippet: Snippet) -> str:
         f"[`{unquoted_path}`](<{file_url}>), {range_info}"
         f"\n-# Repo: [`{snippet.repo}`](<{repo_url}>),"
         f" {ref_type}: [`{snippet.rev}`](<{tree_url}>)"
-        f"\n```{snippet.lang}\n{snippet.body}\n```"
-    )
+    ) + (f"\n```{snippet.lang}\n{snippet.body}\n```" * include_body)
 
 
-async def snippet_message(message: discord.Message) -> tuple[str, int]:
+async def snippet_message(
+    message: discord.Message,
+) -> tuple[tuple[str, list[discord.File]], int]:
     snippets = [s async for s in get_snippets(message.content)]
     if not snippets:
-        return "", 0
+        return ("", []), 0
 
     blobs = list(map(_format_snippet, snippets))
+
+    if len(blobs) == 1 and len(blobs[0]) > 2000:
+        # When there is only a single blob which goes over the limit, upload it
+        # as a file instead.
+        fp = BytesIO(snippets[0].body.encode())
+        file = discord.File(fp, filename=Path(snippets[0].path).name)
+        return (_format_snippet(snippets[0], include_body=False), [file]), 1
 
     if len("\n\n".join(blobs)) > 2000:
         while len("\n\n".join(blobs)) > 1970:  # Accounting for omission note
             blobs.pop()
         if not blobs:
-            return "", -1  # Signal that all snippets were omitted
+            return ("", []), -1  # Signal that all snippets were omitted
         blobs.append("-# Some snippets were omitted")
-    return "\n".join(blobs), len(snippets)
+    return ("\n".join(blobs), []), len(snippets)
 
 
 async def reply_with_code(message: discord.Message) -> None:
     if message.author.bot:
         return
-    msg_content, snippet_count = await snippet_message(message)
+    (msg_content, files), snippet_count = await snippet_message(message)
     if snippet_count != 0:
         await message.edit(suppress=True)
     if snippet_count < 1:
@@ -147,6 +157,7 @@ async def reply_with_code(message: discord.Message) -> None:
 
     sent_message = await message.reply(
         msg_content,
+        files=files,
         suppress_embeds=True,
         mention_author=False,
         allowed_mentions=discord.AllowedMentions.none(),

--- a/app/components/github_integration/comments/integration.py
+++ b/app/components/github_integration/comments/integration.py
@@ -83,5 +83,4 @@ entity_comment_edit_hook = create_edit_hook(
     message_processor=comment_processor,
     interactor=reply_with_comments,
     view_type=DeleteMention,
-    embed_mode=True,
 )

--- a/app/components/xkcd_mentions.py
+++ b/app/components/xkcd_mentions.py
@@ -104,5 +104,4 @@ xkcd_mention_edit_hook = create_edit_hook(
     message_processor=xkcd_mention_message,
     interactor=handle_xkcd_mentions,
     view_type=DeleteButton,
-    embed_mode=True,
 )


### PR DESCRIPTION
I only special-case one code link as the context would then be directly above the file:
![A screenshot.](https://github.com/user-attachments/assets/5f298bd0-4ac7-4abb-8702-8a83a67c932f)
If it were done for all cases, the correspondence between contexts and files would not be apparent as the files are necessarily displayed at the end.

While I *could* do it for the last blob that causes the limit to be exceeded, that might end up being a two line snippet (for example); putting something that small in a file is odd.