### PR TITLE
Disallow whitespace and allow trailing slashes in URLs

### DIFF
--- a/app/components/github_integration/code_links.py
+++ b/app/components/github_integration/code_links.py
@@ -19,8 +19,8 @@ from app.utils import (
 )
 
 CODE_LINK_PATTERN = re.compile(
-    r"https?://(?:www\.)?github\.com/([^/]+)/([^/]+)/blob/([^/]+)/([^\?#]+)(?:[^\#]*)?"
-    r"#L(\d+)(?:C\d+)?(?:-L(\d+)(?:C\d+)?)?"
+    r"https?://(?:www\.)?github\.com/([^/\s]+)/([^/\s]+)/blob/([^/\s]+)/([^\?#\s]+)"
+    r"(?:[^\#\s]*)?#L(\d+)(?:C\d+)?(?:-L(\d+)(?:C\d+)?)?"
 )
 LANG_SUBSTITUTIONS = {
     "el": "lisp",

--- a/app/components/github_integration/code_links.py
+++ b/app/components/github_integration/code_links.py
@@ -70,6 +70,7 @@ class DeleteCodeLink(DeleteMessage):
 async def get_snippets(content: str) -> AsyncIterator[Snippet]:
     for match in CODE_LINK_PATTERN.finditer(content):
         *snippet_path, range_start, range_end = match.groups()
+        snippet_path[-1] = snippet_path[-1].rstrip("/")
 
         snippet_path = SnippetPath(*snippet_path)
         range_start = int(range_start)

--- a/app/components/github_integration/comments/fetching.py
+++ b/app/components/github_integration/comments/fetching.py
@@ -24,7 +24,8 @@ if TYPE_CHECKING:
     from pydantic import BaseModel
 
 COMMENT_PATTERN = re.compile(
-    r"https?://(?:www\.)?github\.com/([^/]+)/([^/]+)/(issues|discussions|pull)/(\d+)#(\w+?-?)(\d+)"
+    r"https?://(?:www\.)?github\.com/([^/\s]+)/([^/\s]+)/"
+    r"(issues|discussions|pull)/(\d+)#(\w+?-?)(\d+)"
 )
 FALLBACK_AUTHOR = GitHubUser(
     login="GitHub",

--- a/app/components/github_integration/comments/fetching.py
+++ b/app/components/github_integration/comments/fetching.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
 COMMENT_PATTERN = re.compile(
     r"https?://(?:www\.)?github\.com/([^/\s]+)/([^/\s]+)/"
-    r"(issues|discussions|pull)/(\d+)#(\w+?-?)(\d+)"
+    r"(issues|discussions|pull)/(\d+)/?#(\w+?-?)(\d+)"
 )
 FALLBACK_AUTHOR = GitHubUser(
     login="GitHub",

--- a/app/components/github_integration/mentions/resolution.py
+++ b/app/components/github_integration/mentions/resolution.py
@@ -15,7 +15,7 @@ ENTITY_REGEX = re.compile(
     r"(?P<owner>\b[a-z0-9\-]+/)?"
     r"(?P<repo>\b[a-z0-9\-\._]+)?"
     r"(?P<sep>/(?:issues|pull|discussions)/|#)"
-    r"(?P<number>\d{1,6})(?!\.\d|#)\b",
+    r"(?P<number>\d{1,6})(?!\.\d|/?#)\b",
     re.IGNORECASE,
 )
 


### PR DESCRIPTION
<code>https://github.com/ghostty-org/gho
st   ty/discussions/7124#discussion-8217793</code> no longer matches, `https://github.com/ghostty-org/ghostty/discussions/7124/#discussion-8217793` now matches.