### PR TITLE
Remove unnecessary emoji variation selectors / Always use Discord SVG emojis

### DIFF
--- a/app/components/accept_invite.py
+++ b/app/components/accept_invite.py
@@ -12,7 +12,7 @@ async def accept_invite(interaction: discord.Interaction) -> None:
     await try_dm(interaction.user, config.ACCEPT_INVITE_URL, silent=True)
     await try_dm(
         interaction.user,
-        "Ghostty is already out! 👉️ https://ghostty.org/",
+        "Ghostty is already out! 👉 https://ghostty.org/",
     )
     await interaction.response.send_message("Check your DMs!", ephemeral=True)
 

--- a/app/components/github_integration/mentions/fmt.py
+++ b/app/components/github_integration/mentions/fmt.py
@@ -83,7 +83,7 @@ def _format_mention(entity: Entity) -> str:
         f" on {fmt_ts('D')} ({fmt_ts('R')})\n"
     )
 
-    emoji = get_entity_emoji(entity) or "❓️"
+    emoji = get_entity_emoji(entity) or "❓"
     return f"{emoji} {headline}\n{subtext}"
 
 

--- a/app/utils/webhooks.py
+++ b/app/utils/webhooks.py
@@ -196,7 +196,7 @@ async def _format_reply(reply: discord.Message) -> discord.Embed:
 
 async def _format_context_menu_command(reply: discord.Message) -> discord.Embed:
     return (await _format_reply(reply)).set_author(
-        name=f"⚡️ Acting on {reply.author.display_name}'s message",
+        name=f"⚡ Acting on {reply.author.display_name}'s message",
         icon_url=reply.author.display_avatar,
     )
 
@@ -275,7 +275,7 @@ def _format_missing_reference(
         )
     return discord.Embed(description="*Original message was deleted.*").set_author(
         name=(
-            "⚡️ Message"
+            "⚡ Message"
             if message.type is discord.MessageType.context_menu_command
             else "↪️ Reply"
         )


### PR DESCRIPTION
With the exception of ⚡️ on some systems and applications, all other changes look like nothing changed; use a hex editor or something similar to view the changes.

-----

The following text is a modified and slightly reduced[^1] Markdown version of the commit message.

Note: all hex sequences below are for text encoded in UTF-8, which is the character encoding this text should have be encoded as, assuming GitHub doesn't do weird nonsense and make it UTF-16.

There are multiple ways to represent the same code-point in Unicode, and these variations are controlled with “Variation Selectors” (there are 16 of these, and they have their own block). The relevant ones here are:
  - just the base code-point (no variation selector): 👍 (f09f 918d);
  - the text variation selector (VS-15): 👍︎ (f09f 918d efb8 8e[^2]); and
  - the emoji variation selector (VS-16): 👍️ (f09f 918d efb8 8f[^3]).

If you use Discord, you likely know that all emojis are converted to SVGs that use Twemoji and are clickable[^4]. However, for whatever reason, Discord seems to *only* convert emojis[^5] that are just the base code-point to SVGs. This makes sense in the case of the text variation, where it likely looks different. However, this can be an annoyance with emojis that have the emoji variation selector, since they use the system emoji font and aren't interactive, but other applications wouldn't show any difference between these two in most cases. These variation selectors snuck in over time whenever I inserted emojis, since the emoji picker I use[^6] includes the emoji variation selector for some emojis that don't strictly need it (but not all, for some reason), which results in them not being converted to SVGs by Discord.

This commit hence strips the emoji variation selector from most (see below) emojis in the code.

There is an exception though: while most emojis default to the emoji presentation, not all do; an example is the heart emoji:
  - base code-point (no variation selector): ❤ (e29d a4)
  - text variation selector (VS-15): ❤︎ (e29d a4ef b88e[^2])
  - emoji variation selector (VS-16): ❤️ (e29d a4ef b88f[^3])

Assuming a complaint application, both the first and the second will likely be black or white, while the second would be the heart emoji from your emoji font[^7].

Luckily, Discord handles these correctly, and handles these with the emoji variation when using its emoji picker, and also converts emojis that have the emoji variation selector for these emojis to SVGs. The base code-point remains as the text variation for these, and the text variation also remains as the text variation; a literal emoji character that is presented with the emoji variation cannot be acquirable without escaping it[^5]. This means that the emoji variation selector must remain, for a different variation would be used were it to be removed; this is the reason why not all variation selectors have been removed.

[^1]: That is, some things are missing; Markdown is a superset of HTML, so this will almost certainly be read in a browser, while such guarantees don't hold for the commit message.

[^2]: The Unicode code-point of VS-15 is U+FE0E.

[^3]: The Unicode code-point of VS-16 is U+FE0F.

[^4]: You may have found that Discord (since at least 2024) also makes the SVGs slightly larger than the line height, which makes actual emoji characters look slightly smaller as well.

[^5]: A backslash before an emoji always escapes it, which makes Discord avoid touching it. This means that a backslash can make an emoji be forced to use the system emoji font, rather than being converted to a SVG.

[^6]: The emoji picker I use is Smile: <https://smile.mijorus.it>.

[^7]: Unless you changed it, the default is Noto Sans Emoji on Android and most Linux distros (and probably BSDs too), Apple Color Emoji on iOS, iPadOS, macOS, visionOS, watchOS, and other Apple operating systems, and Segoe UI on Windows.