### PR TITLE
Make `.m` files use objective-c syntax highlighting

### DIFF
--- a/app/components/github_integration/code_links.py
+++ b/app/components/github_integration/code_links.py
@@ -26,6 +26,7 @@ LANG_SUBSTITUTIONS = {
     "el": "lisp",
     "pyi": "py",
     "fnl": "clojure",
+    "m": "objc",
 }
 
 


### PR DESCRIPTION
`.m` is nothing in highlight.js and [Mercury] in Shiki, and neither Mercury nor MATLAB are as likely especially among the audience of Ghosttycord for there to be any use to having them used over objective-c.  This is especially useful with #233 because the file doesn't embed unless highlight.js supports it.

[Mercury]: https://mercurylang.org