### PR TITLE
hide empty diff sizes for PR mentions

### DIFF
--- a/app/components/github_integration/mentions/fmt.py
+++ b/app/components/github_integration/mentions/fmt.py
@@ -82,6 +82,8 @@ def _format_entity_detail(entity: Entity) -> str:
             labels, omission_note = entity.labels, ""
         body = f"labels: {', '.join(f'`{label}`' for label in labels)}{omission_note}"
     elif isinstance(entity, PullRequest):
+        if not (entity.additions or entity.deletions or entity.changed_files):
+            return ""  # Diff size unavailable
         body = (
             f"diff size: `+{entity.additions}` `-{entity.deletions}`"
             f" ({entity.changed_files} files changed)"


### PR DESCRIPTION
Closes #278. Looks like GitHub just expires some diffs (I'd guess deleted forks) after some time:
```
λ curl "https://patch-diff.githubusercontent.com/raw/ghostty-org/ghostty/pull/1234.patch"
Sorry, this diff is unavailable.
```
```
λ curl "https://patch-diff.githubusercontent.com/raw/ghostty-org/ghostty/pull/7149.patch"
From d4525f2c575b48553499b58d4e680e139dcc36ab Mon Sep 17 00:00:00 2001
From: Kat <65649991+00-kat@users.noreply.github.com>
Date: Mon, 21 Apr 2025 03:41:52 +0000
Subject: [PATCH] Correct remaining instances of `change_title_prompt` to
 `prompt_surface_title`.

---
 macos/Sources/App/macOS/AppDelegate.swift | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

diff --git a/macos/Sources/App/macOS/AppDelegate.swift b/macos/Sources/App/macOS/AppDelegate.swift
index 9d866d7341..e9ef00347b 100644
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -398,7 +398,7 @@ class AppDelegate: NSObject,
         syncMenuShortcut(config, action: "increase_font_size:1", menuItem: self.menuIncreaseFontSize)
         syncMenuShortcut(config, action: "decrease_font_size:1", menuItem: self.menuDecreaseFontSize)
         syncMenuShortcut(config, action: "reset_font_size", menuItem: self.menuResetFontSize)
-        syncMenuShortcut(config, action: "change_title_prompt", menuItem: self.menuChangeTitle)
+        syncMenuShortcut(config, action: "prompt_surface_title", menuItem: self.menuChangeTitle)
         syncMenuShortcut(config, action: "toggle_quick_terminal", menuItem: self.menuQuickTerminal)
         syncMenuShortcut(config, action: "toggle_visibility", menuItem: self.menuToggleVisibility)
         syncMenuShortcut(config, action: "inspector:toggle", menuItem: self.menuTerminalInspector)
```