### PR TITLE
fix: SGR 0 only applied inside codeblocks

### DIFF
--- a/app/components/zig_codeblocks.py
+++ b/app/components/zig_codeblocks.py
@@ -58,19 +58,14 @@ def apply_discord_wa(source: str) -> str:
     return source.replace("///", "\x1b[0m///").replace("// ", "\x1b[0m// ")
 
 
-def _apply_discord_wa_in_only_codeblock(source: str) -> str:
+def _apply_discord_wa_in_ansi_codeblocks(source: str) -> str:
     # Resolves #274
     code_blocks = extract_codeblocks(source)
-    code_blocks = [  # Remove duplicates
-        v1
-        for i, v1 in enumerate(code_blocks)
-        if not any(
-            (v1.body == v2.body) and (v1.lang == v2.lang) for v2 in code_blocks[:i]
-        )
-    ]
+    # Remove duplicates
+    code_blocks = [cb for i, cb in enumerate(code_blocks) if cb not in code_blocks[:i]]
     for block in code_blocks:
         if block.lang == "ansi":
-            body = f"```{block.lang}\n{block.body}```"
+            body = str(block)
             source = source.replace(body, apply_discord_wa(body))
     return source
 
@@ -82,7 +77,7 @@ class CodeblockActions(ItemActions):
 
     def __init__(self, message: dc.Message, item_count: int) -> None:
         super().__init__(message, item_count)
-        replaced_content = _apply_discord_wa_in_only_codeblock(
+        replaced_content = _apply_discord_wa_in_ansi_codeblocks(
             process_markdown(message.content, THEME)
         )
         if len(replaced_content) > 2000:

--- a/app/components/zig_codeblocks.py
+++ b/app/components/zig_codeblocks.py
@@ -36,9 +36,6 @@ OMISSION_NOTE = "\n-# {} codeblock{} omitted"
 # This pattern is intentionally simple; it's only meant to operate on sequences produced
 # by zig-codeblocks which will never appear in any other form.
 SGR_PATTERN = re.compile(r"\x1b\[[0-9;]+m")
-# Pattern is inspired by zig-codeblocks,
-# but capture groups are removed and only ANSI code is matched
-CODE_BLOCK_PATTERN = re.compile(r"(?si)(```(?:(?:ansi\W*)(?:\r?\n)+(?:[^\r\n].*?))```)")
 THEME = DEFAULT_THEME.copy()
 del THEME["Comment"]
 
@@ -63,13 +60,11 @@ def apply_discord_wa(source: str) -> str:
 
 def _apply_discord_wa_in_only_codeblock(source: str) -> str:
     # Resolves #274
-    processed_blocks: list[str] = []
-    for block in CODE_BLOCK_PATTERN.split(source):
-        if CODE_BLOCK_PATTERN.match(block):
-            processed_blocks.append(apply_discord_wa(block))
-        else:
-            processed_blocks.append(block)
-    return "".join(processed_blocks)
+    code_blocks = extract_codeblocks(source)
+    for block in code_blocks:
+        if block.lang == "ansi":
+            source = source.replace(block.body, apply_discord_wa(block.body))
+    return source
 
 
 class CodeblockActions(ItemActions):

--- a/app/components/zig_codeblocks.py
+++ b/app/components/zig_codeblocks.py
@@ -61,9 +61,17 @@ def apply_discord_wa(source: str) -> str:
 def _apply_discord_wa_in_only_codeblock(source: str) -> str:
     # Resolves #274
     code_blocks = extract_codeblocks(source)
+    code_blocks = [  # Remove duplicates
+        v1
+        for i, v1 in enumerate(code_blocks)
+        if not any(
+            (v1.body == v2.body) and (v1.lang == v2.lang) for v2 in code_blocks[:i]
+        )
+    ]
     for block in code_blocks:
         if block.lang == "ansi":
-            source = source.replace(block.body, apply_discord_wa(block.body))
+            body = f"```{block.lang}\n{block.body}```"
+            source = source.replace(body, apply_discord_wa(body))
     return source
 
 

--- a/app/components/zig_codeblocks.py
+++ b/app/components/zig_codeblocks.py
@@ -36,10 +36,9 @@ OMISSION_NOTE = "\n-# {} codeblock{} omitted"
 # This pattern is intentionally simple; it's only meant to operate on sequences produced
 # by zig-codeblocks which will never appear in any other form.
 SGR_PATTERN = re.compile(r"\x1b\[[0-9;]+m")
-# Pattern is from zig-codeblocks, but capture groups are removed
-CODE_BLOCK_PATTERN = re.compile(
-    r"(?s)(```(?:(?:[A-Za-z0-9\-_\+\.#]+)(?:\r?\n)+(?:[^\r\n].*?)|(?:.*?))```)"
-)
+# Pattern is inspired by zig-codeblocks,
+# but capture groups are removed and only ANSI code is matched
+CODE_BLOCK_PATTERN = re.compile(r"(?si)(```(?:(?:ansi\W*)(?:\r?\n)+(?:[^\r\n].*?))```)")
 THEME = DEFAULT_THEME.copy()
 del THEME["Comment"]
 


### PR DESCRIPTION
Resolves #274

This PR only applies the discord work around from within the codeblocks. This is the cleanest solution I could come up with, without modifying the upstream library. 

Thing to note, I also made it only change code inside ANSI codeblocks. Don't want to do the sub on "multi codeblock" messages.

<img width="802" height="466" alt="image" src="https://github.com/user-attachments/assets/820ec381-a55a-4ff2-9c20-13d358ae52a0" />

Example:

````md
In python `2 // 3` is 0 and 2 in zig
```py
2 // 3
```
Outputs 0

```zig
2 // 3
```
Outputs 2

hi! // hello!!

```py
# Extra disambiguous codeblock that doesn't show up in replace interaction
```
````

