### PR TITLE
Add `/close upstream` as an alternative to `/close wontfix`

### DIFF
--- a/app/components/close_help_post.py
+++ b/app/components/close_help_post.py
@@ -94,6 +94,10 @@ class Close(app_commands.Group):
     async def wontfix(self, interaction: dc.Interaction) -> None:
         await close_post(interaction, "stale", "[WON'T FIX]")
 
+    @app_commands.command(name="upstream", description="Mark post as stale.")
+    async def upstream(self, interaction: dc.Interaction) -> None:
+        await close_post(interaction, "stale", "[UPSTREAM]")
+
 
 bot.tree.add_command(Close(name="close", description="Mark current post as resolved."))
 


### PR DESCRIPTION
`/close wontfix` is often used for upstream issues so this makes the intent more obvious.