### PR TITLE
webhook: handle PR events

### DIFF
--- a/app/components/github_integration/webhooks/__init__.py
+++ b/app/components/github_integration/webhooks/__init__.py
@@ -1,3 +1,4 @@
+from . import prs as prs
 from .core import client as monalisten_client
 
 __all__ = ("monalisten_client",)

--- a/app/components/github_integration/webhooks/core.py
+++ b/app/components/github_integration/webhooks/core.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from githubkit.versions.latest.models import SimpleUser
     from monalisten import AuthIssue
 
-type EmbedColor = Literal["green", "red", "purple", "gray"]
+type EmbedColor = Literal["green", "red", "purple", "gray", "orange"]
 type SubhookStore[E] = dict[str, Callable[[E], Awaitable[None]]]
 
 EMBED_COLORS: dict[EmbedColor, int] = {
@@ -24,6 +24,7 @@ EMBED_COLORS: dict[EmbedColor, int] = {
     "purple": 0xAB7DF8,
     "red": 0xF85149,
     "gray": 0x9198A1,
+    "orange": 0xEDB74A,
 }
 
 client = Monalisten(config.github_webhook_url, token=config.github_webhook_secret)

--- a/app/components/github_integration/webhooks/core.py
+++ b/app/components/github_integration/webhooks/core.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, NamedTuple, TypedDict
 
 import discord as dc
-from githubkit.versions.latest.models import SimpleUser
 from monalisten import Monalisten
 
 from app.components.github_integration.emoji import EmojiName, emojis
@@ -12,7 +11,18 @@ from app.setup import config
 from app.utils import truncate
 
 if TYPE_CHECKING:
+    from githubkit.versions.latest.models import SimpleUser
     from monalisten import AuthIssue
+
+type EmbedColor = Literal["green", "red", "purple", "gray"]
+
+EMBED_COLORS: dict[EmbedColor, int] = {
+    "green": 0x3FB950,
+    "purple": 0xAB7DF8,
+    "red": 0xF85149,
+    "gray": 0x9198A1,
+}
+
 client = Monalisten(config.github_webhook_url, token=config.github_webhook_secret)
 
 
@@ -63,11 +73,11 @@ async def send_embed(
     content: EmbedContent,
     footer: Footer,
     *,
-    color: int | None = None,
+    color: EmbedColor | None = None,
 ) -> None:
     author = GitHubUser(**actor.model_dump())
     embed = (
-        dc.Embed(color=color, **content.dict)
+        dc.Embed(color=color and EMBED_COLORS.get(color), **content.dict)
         .set_footer(**footer.dict)
         .set_author(**author.model_dump())
     )

--- a/app/components/github_integration/webhooks/prs.py
+++ b/app/components/github_integration/webhooks/prs.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import datetime as dt
-from typing import TYPE_CHECKING
+from itertools import dropwhile
+from typing import TYPE_CHECKING, Any, Literal, cast
 
+from app.components.github_integration.comments.fetching import FALLBACK_AUTHOR
+from app.components.github_integration.models import GitHubUser
 from app.components.github_integration.webhooks.core import (
     EmbedContent,
     Footer,
@@ -14,7 +17,6 @@ from app.components.github_integration.webhooks.core import (
 
 if TYPE_CHECKING:
     from githubkit.versions.v2022_11_28.models import (
-        PullRequestWebhook,
         WebhookPullRequestClosed,
         WebhookPullRequestConvertedToDraft,
         WebhookPullRequestEdited,
@@ -22,25 +24,46 @@ if TYPE_CHECKING:
         WebhookPullRequestOpened,
         WebhookPullRequestReadyForReview,
         WebhookPullRequestReopened,
+        WebhookPullRequestReviewCommentCreated,
+        WebhookPullRequestReviewDismissed,
+        WebhookPullRequestReviewRequestedOneof0,
+        WebhookPullRequestReviewRequestedOneof1,
+        WebhookPullRequestReviewRequestRemovedOneof0,
+        WebhookPullRequestReviewRequestRemovedOneof1,
+        WebhookPullRequestReviewSubmitted,
         WebhookPullRequestUnlocked,
     )
     from monalisten.types import (
         PullRequestEvent,
+        PullRequestReviewCommentEvent,
+        PullRequestReviewEvent,
     )
 
     from app.components.github_integration.emoji import EmojiName
 
+type WebhookPullRequestReviewRequested = (
+    WebhookPullRequestReviewRequestedOneof0 | WebhookPullRequestReviewRequestedOneof1
+)
+type WebhookPullRequestReviewRequestRemoved = (
+    WebhookPullRequestReviewRequestRemovedOneof0
+    | WebhookPullRequestReviewRequestRemovedOneof1
+)
+
+HUNK_CODEBLOCK_OVERHEAD = len("```diff\n\n```\n")
+
 pr_subhooks: SubhookStore[PullRequestEvent] = {}
+pr_review_subhooks: SubhookStore[PullRequestReviewEvent] = {}
 
 register_pr_subhook = make_subhook_registrar(pr_subhooks)
+register_pr_review_subhook = make_subhook_registrar(pr_review_subhooks)
 
 
-def get_pr_emoji(pull_request: PullRequestWebhook) -> EmojiName:
-    return "pull_" + (
-        "draft" if pull_request.draft
-        else "merged" if pull_request.merged
-        else pull_request.state
-    )  # fmt: skip
+def get_pr_emoji(pull_request: Any, *, from_review: bool = False) -> EmojiName:
+    # pull_request_review(_comment) events have pull_request objects that don't have
+    # the .merged field, so we have to fall back to checking if .merged_at is non-None
+    merged = pull_request.merged_at is not None if from_review else pull_request.merged
+    state = cast("Literal['open', 'closed']", pull_request.state)
+    return "pull_" + ("draft" if pull_request.draft else "merged" if merged else state)
 
 
 @client.on("pull_request")
@@ -156,3 +179,122 @@ async def handle_unlocked_pr(event: WebhookPullRequestUnlocked) -> None:
         EmbedContent(f"unlocked PR #{number}", pr.html_url),
         Footer(get_pr_emoji(pr), f"PR #{number}: {pr.title}"),
     )
+
+
+@register_pr_subhook("review_requested")
+async def handle_pr_review_request(event: WebhookPullRequestReviewRequested) -> None:
+    pr, number = event.pull_request, event.number
+    content = f"from {_format_reviewer(event)}"
+    await send_embed(
+        event.sender,
+        EmbedContent(f"requested review for PR #{number}", pr.html_url, content),
+        Footer(get_pr_emoji(pr), f"PR #{number}: {pr.title}"),
+    )
+
+
+@register_pr_subhook("review_request_removed")
+async def handle_pr_removed_review_request(
+    event: WebhookPullRequestReviewRequestRemoved,
+) -> None:
+    pr, number = event.pull_request, event.number
+    content = f"from {_format_reviewer(event)}"
+    await send_embed(
+        event.sender,
+        EmbedContent(f"removed review request for PR #{number}", pr.html_url, content),
+        Footer(get_pr_emoji(pr), f"PR #{number}: {pr.title}"),
+    )
+
+
+# Abusing `Any`/`getattr`/`hasattr` here because the API models are insufferable
+def _format_reviewer(event: Any) -> str:
+    if hasattr(event, "requested_team"):
+        return f"the `{event.requested_team.name}` team"
+    if requested_reviewer := getattr(event, "requested_reviewer", None):
+        return GitHubUser(**requested_reviewer.model_dump()).hyperlink
+    return "`?`"
+
+
+@client.on("pull_request_review")
+async def handle_pr_review_event(event: PullRequestReviewEvent) -> None:
+    if subhook := pr_review_subhooks.get(event.action):
+        await subhook(event)
+
+
+@register_pr_review_subhook("submitted")
+async def handle_pr_review_submitted(event: WebhookPullRequestReviewSubmitted) -> None:
+    pr, number = event.pull_request, event.pull_request.number
+    match event.review.state:
+        case "approved":
+            color, title = "green", "approved"
+        case "commented":
+            color, title = None, "reviewed"
+        case "changes_requested":
+            color, title = "red", "requested changes in"
+        case s:
+            print("Unexpected review state in handle_pr_review_submitted:", s)
+            return
+
+    emoji = "pull_" + ("draft" if pr.draft else "merged" if pr.merged_at else pr.state)
+    await send_embed(
+        event.sender,
+        EmbedContent(f"{title} PR #{number}", pr.html_url, event.review.body),
+        Footer(emoji, f"PR #{number}: {pr.title}"),
+        color=color,
+    )
+
+
+@register_pr_review_subhook("dismissed")
+async def handle_pr_review_dismissed(
+    event: WebhookPullRequestReviewDismissed,
+) -> None:
+    pr, number = event.pull_request, event.pull_request.number
+    emoji = "pull_" + ("draft" if pr.draft else "merged" if pr.merged_at else pr.state)
+    review_author = (
+        GitHubUser(**event.review.user.model_dump())
+        if event.review.user
+        else FALLBACK_AUTHOR
+    )
+    await send_embed(
+        event.sender,
+        EmbedContent(
+            f"dismissed a PR #{number} review",
+            pr.html_url,
+            f"authored by {review_author.hyperlink}",
+        ),
+        Footer(emoji, f"PR #{number}: {pr.title}"),
+        color="orange",
+    )
+
+
+@client.on("pull_request_review_comment")
+async def handle_pr_review_comment_event(
+    event: PullRequestReviewCommentEvent,
+) -> None:
+    if event.action == "created":
+        await handle_pr_review_comment_created(event)
+
+
+async def handle_pr_review_comment_created(
+    event: WebhookPullRequestReviewCommentCreated,
+) -> None:
+    pr, number = event.pull_request, event.pull_request.number
+    content = event.comment.body
+
+    hunk = _reduce_diff_hunk(event.comment.diff_hunk)
+    if 500 - len(content) - len(hunk) - HUNK_CODEBLOCK_OVERHEAD >= 0:
+        # We can fit a hunk!
+        content = f"```diff\n{hunk}\n```\n{content}"
+
+    await send_embed(
+        event.sender,
+        EmbedContent(f"left a review comment on PR #{number}", pr.html_url, content),
+        Footer(get_pr_emoji(pr, from_review=True), f"PR #{number}: {pr.title}"),
+    )
+
+
+def _reduce_diff_hunk(hunk: str) -> str:
+    def missing_diff_marker(line: str) -> bool:
+        return not line.startswith(("-", "+"))
+
+    hunk_lines = [*dropwhile(missing_diff_marker, hunk.splitlines())]
+    return "\n".join([*dropwhile(missing_diff_marker, hunk_lines[::-1])][::-1])

--- a/app/components/github_integration/webhooks/prs.py
+++ b/app/components/github_integration/webhooks/prs.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import datetime as dt
+from typing import TYPE_CHECKING
+
+from app.components.github_integration.webhooks.core import (
+    EmbedContent,
+    Footer,
+    SubhookStore,
+    client,
+    make_subhook_registrar,
+    send_embed,
+)
+
+if TYPE_CHECKING:
+    from githubkit.versions.v2022_11_28.models import (
+        PullRequestWebhook,
+        WebhookPullRequestClosed,
+        WebhookPullRequestConvertedToDraft,
+        WebhookPullRequestEdited,
+        WebhookPullRequestLocked,
+        WebhookPullRequestOpened,
+        WebhookPullRequestReadyForReview,
+        WebhookPullRequestReopened,
+        WebhookPullRequestUnlocked,
+    )
+    from monalisten.types import (
+        PullRequestEvent,
+    )
+
+    from app.components.github_integration.emoji import EmojiName
+
+pr_subhooks: SubhookStore[PullRequestEvent] = {}
+
+register_pr_subhook = make_subhook_registrar(pr_subhooks)
+
+
+def get_pr_emoji(pull_request: PullRequestWebhook) -> EmojiName:
+    return "pull_" + (
+        "draft" if pull_request.draft
+        else "merged" if pull_request.merged
+        else pull_request.state
+    )  # fmt: skip
+
+
+@client.on("pull_request")
+async def handle_pr_event(event: PullRequestEvent) -> None:
+    if subhook := pr_subhooks.get(event.action):
+        await subhook(event)
+
+
+@register_pr_subhook("opened")
+async def handle_opened_pr(event: WebhookPullRequestOpened) -> None:
+    pr, number = event.pull_request, event.number
+    await send_embed(
+        event.sender,
+        EmbedContent(f"opened PR #{number}", pr.html_url, pr.body),
+        Footer("pull_open", f"PR #{number}: {pr.title}"),
+        color="green",
+    )
+
+
+@register_pr_subhook("closed")
+async def handle_closed_pr(event: WebhookPullRequestClosed) -> None:
+    pr, number = event.pull_request, event.number
+    action, color = ("merged", "purple") if pr.merged else ("closed", "red")
+    await send_embed(
+        event.sender,
+        EmbedContent(f"{action} PR #{number}", pr.html_url),
+        Footer("pull_" + action, f"PR #{number}: {pr.title}"),
+        color=color,
+    )
+
+
+@register_pr_subhook("reopened")
+async def handle_reopened_pr(event: WebhookPullRequestReopened) -> None:
+    pr, number = event.pull_request, event.number
+    await send_embed(
+        event.sender,
+        EmbedContent(f"reopened PR #{number}", pr.html_url),
+        Footer("pull_open", f"PR #{number}: {pr.title}"),
+        color="green",
+    )
+
+
+@register_pr_subhook("edited")
+async def handle_edited_pr(event: WebhookPullRequestEdited) -> None:
+    pr, number, changes = event.pull_request, event.number, event.changes
+
+    if pr.created_at > dt.datetime.now(tz=dt.UTC) - dt.timedelta(minutes=15):
+        return
+
+    update_notes: list[str] = []
+    if changes.title:
+        update_notes.append(f'Renamed from "{changes.title.from_}" to "{pr.title}"')
+    if changes.body:
+        update_notes.append("Updated description")
+
+    match update_notes:
+        case [note]:
+            content = note
+        case [note1, note2]:
+            content = f"* {note1}\n*\n {note2}"
+        case _:
+            return
+
+    assert event.sender
+    await send_embed(
+        event.sender,
+        EmbedContent(f"edited PR #{number}", pr.html_url, content),
+        Footer(get_pr_emoji(pr), f"PR #{number}: {pr.title}"),
+    )
+
+
+@register_pr_subhook("converted_to_draft")
+async def handle_drafted_pr(event: WebhookPullRequestConvertedToDraft) -> None:
+    pr, number = event.pull_request, event.number
+    await send_embed(
+        event.sender,
+        EmbedContent(f"converted PR #{number} to draft", pr.html_url),
+        Footer("pull_draft", f"PR #{number}: {pr.title}"),
+        color="gray",
+    )
+
+
+@register_pr_subhook("ready_for_review")
+async def handle_undrafted_pr(event: WebhookPullRequestReadyForReview) -> None:
+    pr, number = event.pull_request, event.number
+    await send_embed(
+        event.sender,
+        EmbedContent(f"marked PR #{number} as ready for review", pr.html_url),
+        Footer("pull_open", f"PR #{number}: {pr.title}"),
+        color="green",
+    )
+
+
+@register_pr_subhook("locked")
+async def handle_locked_pr(event: WebhookPullRequestLocked) -> None:
+    pr, number = event.pull_request, event.number
+    title = f"locked PR #{number}"
+    if reason := pr.active_lock_reason:
+        title += f" as {reason}"
+    await send_embed(
+        event.sender,
+        EmbedContent(title, pr.html_url),
+        Footer(get_pr_emoji(pr), f"PR #{number}: {pr.title}"),
+        color="orange",
+    )
+
+
+@register_pr_subhook("unlocked")
+async def handle_unlocked_pr(event: WebhookPullRequestUnlocked) -> None:
+    pr, number = event.pull_request, event.number
+    await send_embed(
+        event.sender,
+        EmbedContent(f"unlocked PR #{number}", pr.html_url),
+        Footer(get_pr_emoji(pr), f"PR #{number}: {pr.title}"),
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "sentry-sdk~=2.35",
   "zig-codeblocks==0.3.3",
   "httpx~=0.28.1",
-  "monalisten==0.1.1",
+  "monalisten==0.2.0",
   "pydantic-settings>=2.10.1,<3",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -247,7 +247,7 @@ requires-dist = [
     { name = "discord-py", specifier = "~=2.5.0" },
     { name = "githubkit", specifier = "~=0.13.1" },
     { name = "httpx", specifier = "~=0.28.1" },
-    { name = "monalisten", specifier = "==0.1.1" },
+    { name = "monalisten", specifier = "==0.2.0" },
     { name = "pydantic", specifier = ">=2.11.7,<3" },
     { name = "pydantic-settings", specifier = ">=2.10.1,<3" },
     { name = "sentry-sdk", specifier = "~=2.35" },
@@ -357,16 +357,16 @@ wheels = [
 
 [[package]]
 name = "monalisten"
-version = "0.1.1"
+version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "githubkit" },
     { name = "httpx" },
     { name = "httpx-sse" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/09/d2/281ad15aaca06f7303f2fdf5859b3d991c9131e13654393ffe96ca06dbfa/monalisten-0.1.1.tar.gz", hash = "sha256:bb3e9984ae4895aeae64b6a190bd0e71c4a9d0aaaca65ba07398618f1cccfbb5", size = 6276, upload-time = "2025-08-20T09:34:58.642Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b1/3351004b20fb608653f8da587e3e436befc960910d19218cf16b8f42eb76/monalisten-0.2.0.tar.gz", hash = "sha256:6877a8cf0bd933a399d002c247ad36688133934afec75534408535e74c573dbe", size = 7881, upload-time = "2025-08-23T16:36:05.785Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/dd/51e7ec8904c08cad6ff8aa0a82a98d14e3c8f2aea5755532f67e27860e9f/monalisten-0.1.1-py3-none-any.whl", hash = "sha256:2502979c02195b6f03d537b380f0e45f9e29e91dab353ef03887dd1f50786c20", size = 7399, upload-time = "2025-08-20T09:34:57.722Z" },
+    { url = "https://files.pythonhosted.org/packages/00/f4/9fe55ec1de48f94d40c75cb5db341663f97e09a720e8bb02506a60745ea6/monalisten-0.2.0-py3-none-any.whl", hash = "sha256:c9366072bfe5ed27f4e9b82691c5fe65af18e2b0afbf714a6043b2dd524d4161", size = 9058, upload-time = "2025-08-23T16:36:04.64Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The following events are now supported:
* PRs:
  * (re)opened
  * closed/merged
  * edited
  * (un)drafted
  * (un)locked
* PR reviews:
  * (un)requested
  * submitted/dismissed
  * comment created (review comments, not regular comments, that's gonna be covered by an issues PR)