### PR TITLE
fix: ensure secrets are not leaked in logs

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -4,7 +4,7 @@ from app.core import bot, config
 
 if config.sentry_dsn is not None:
     sentry_sdk.init(
-        dsn=config.sentry_dsn,
+        dsn=config.sentry_dsn.get_secret_value(),
         traces_sample_rate=1.0,
         profiles_sample_rate=1.0,
     )
@@ -12,4 +12,4 @@ if config.sentry_dsn is not None:
 # Our logging is handled by Loguru, and logs from the standard logging module are
 # forwarded to Loguru in setup.py; hence, disable discord.py's log handler to avoid
 # duplicated logs showing up in stderr.
-bot.run(config.token, log_handler=None)
+bot.run(config.token.get_secret_value(), log_handler=None)

--- a/app/components/github_integration/webhooks/core.py
+++ b/app/components/github_integration/webhooks/core.py
@@ -29,7 +29,12 @@ EMBED_COLORS: dict[EmbedColor, int] = {
     "blue": 0x4C8CED,
 }
 
-client = Monalisten(config.github_webhook_url, token=config.github_webhook_secret)
+client = Monalisten(
+    config.github_webhook_url.get_secret_value(),
+    token=config.github_webhook_secret.get_secret_value()
+    if config.github_webhook_secret
+    else None,
+)
 
 
 @client.on_internal("auth_issue")


### PR DESCRIPTION
A few changes are implemented here:
* Pydantic uses [SecretStr](https://docs.pydantic.dev/2.0/usage/types/secrets/) (Helping prevent secret from making it out during config construction)
  * Modify usage of changed type to extract string value
* Setup #314 Loguru _before_ constructing discord bot, to fully capture all of its messages


A side effect is that the init logs now look like:
```log
2025-08-27 14:06:43.058 | WARNING  | discord.client:__init__:318 - PyNaCl is not installed, voice will NOT be supported
2025-08-27 14:06:43.173 | INFO     | sentry_sdk.integrations.logging:sentry_patched_callhandlers:128 - logging in using static token
2025-08-27 14:06:44.120 | INFO     | sentry_sdk.integrations.logging:sentry_patched_callhandlers:128 - Shard ID None has connected to Gateway (Session ID: 18ad6340f47c8a12dd8d4de59f777768).
```
With the voice warning being populated at the start.