### PR TITLE
chore: remove need for explicit preview flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: uv run taplo fmt --check --diff pyproject.toml
       - name: ruff format
         if: ${{ !cancelled() && steps.sync.conclusion == 'success' }}
-        run: uv run ruff format --preview --diff
+        run: uv run ruff format --diff
       - name: ruff lint
         if: ${{ !cancelled() && steps.sync.conclusion == 'success' }}
         run: uv run ruff check --output-format github

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ This bot runs on Python 3.13+ and is managed with [uv]. To get started:
 3. After you've made your changes, run the required checks:
    ```console
    $ uv run ruff check
-   $ uv run ruff format --preview
+   $ uv run ruff format
    $ uv run basedpyright app tests
    $ uv run taplo fmt pyproject.toml
    $ uv run pytest

--- a/justfile
+++ b/justfile
@@ -5,7 +5,7 @@ default:
 # Run taplo, ruff, pytest, and basedpyright in check mode
 check:
     uv run taplo fmt --check --diff pyproject.toml
-    uv run ruff format --preview --check
+    uv run ruff format --check
     uv run ruff check
     uv run pytest
     uv run basedpyright app tests
@@ -13,5 +13,5 @@ check:
 # Run taplo and ruff in fix mode
 fix:
     uv run taplo fmt pyproject.toml
-    uv run ruff format --preview
+    uv run ruff format
     uv run ruff check --fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ pylint.max-branches = 20
 pylint.max-returns = 15
 isort.known-local-folder = ["app"]
 
+[tool.ruff.format]
+preview = true
+
 [tool.ruff.lint.flake8-import-conventions.aliases]
 discord = "dc"
 


### PR DESCRIPTION
This PR simplifies the format setting, putting format in preview mode through the config file instead of the CLI.

The motivation for this, is two things. A) allows for consistent command CLI usage in all projects (regardless of if your project uses preview mode or not) and B) enables consistent rule definition in a single location. Easy to get out of preview mode later.