### PR TITLE
webhooks: support `issues.edited`

### DIFF
--- a/app/components/github_integration/webhooks/issues.py
+++ b/app/components/github_integration/webhooks/issues.py
@@ -153,7 +153,7 @@ async def handle_edited_issue(event: WebhookIssuesEdited) -> None:
         case [note]:
             content = note
         case [note1, note2]:
-            content = f"* {note1}\n*\n {note2}"
+            content = f"* {note1}\n* {note2}"
         case _:
             return
 

--- a/app/components/github_integration/webhooks/issues.py
+++ b/app/components/github_integration/webhooks/issues.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime as dt
 import re
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
@@ -20,6 +21,7 @@ if TYPE_CHECKING:
     from githubkit.versions.latest.models import (
         WebhookIssueCommentCreated,
         WebhookIssuesClosed,
+        WebhookIssuesEdited,
         WebhookIssuesLocked,
         WebhookIssuesOpened,
         WebhookIssuesPinned,
@@ -131,6 +133,34 @@ async def handle_reopened_issue(event: WebhookIssuesReopened) -> None:
         issue_embed_content(issue, "reopened {}"),
         issue_footer(issue, emoji="issue_open"),
         color="green",
+    )
+
+
+@register_issue_subhook("edited")
+async def handle_edited_issue(event: WebhookIssuesEdited) -> None:
+    issue, changes = event.issue, event.changes
+
+    if issue.created_at > dt.datetime.now(tz=dt.UTC) - dt.timedelta(minutes=15):
+        return
+
+    update_notes: list[str] = []
+    if changes.title:
+        update_notes.append(f'Renamed from "{changes.title.from_}" to "{issue.title}"')
+    if changes.body:
+        update_notes.append("Updated description")
+
+    match update_notes:
+        case [note]:
+            content = note
+        case [note1, note2]:
+            content = f"* {note1}\n*\n {note2}"
+        case _:
+            return
+
+    await send_embed(
+        event.sender,
+        issue_embed_content(issue, "edited {}", content),
+        issue_footer(issue),
     )
 
 

--- a/app/components/github_integration/webhooks/prs.py
+++ b/app/components/github_integration/webhooks/prs.py
@@ -145,7 +145,7 @@ async def handle_edited_pr(event: WebhookPullRequestEdited) -> None:
         case [note]:
             content = note
         case [note1, note2]:
-            content = f"* {note1}\n*\n {note2}"
+            content = f"* {note1}\n* {note2}"
         case _:
             return
 


### PR DESCRIPTION
This is almost a 1:1 copy of `pull_request.edited`. I'm looking to DRY this out when I get around to using `difflib`.