### PR TITLE
Rename move_message_via_webhook() to move_message()

### DIFF
--- a/app/common/message_moving.py
+++ b/app/common/message_moving.py
@@ -515,7 +515,7 @@ class MovedMessage(ExtensibleMessage, dc.WebhookMessage):  # pyright: ignore[rep
 
 
 @overload
-async def move_message_via_webhook(
+async def move_message(
     bot: GhosttyBot,
     webhook: dc.Webhook,
     message: dc.Message,
@@ -528,7 +528,7 @@ async def move_message_via_webhook(
 
 
 @overload
-async def move_message_via_webhook(
+async def move_message(
     bot: GhosttyBot,
     webhook: dc.Webhook,
     message: dc.Message,
@@ -540,7 +540,7 @@ async def move_message_via_webhook(
 ) -> dc.WebhookMessage: ...
 
 
-async def move_message_via_webhook(  # noqa: PLR0913
+async def move_message(  # noqa: PLR0913
     bot: GhosttyBot,
     webhook: dc.Webhook,
     message: dc.Message,

--- a/app/components/move_message.py
+++ b/app/components/move_message.py
@@ -16,7 +16,7 @@ from app.common.message_moving import (
     convert_nitro_emojis,
     get_or_create_webhook,
     message_can_be_moved,
-    move_message_via_webhook,
+    move_message,
 )
 from app.errors import SafeModal, SafeView
 from app.utils import (
@@ -188,7 +188,7 @@ class SelectChannel(SafeView):
         assert isinstance(webhook_channel, dc.TextChannel | dc.ForumChannel)
 
         webhook = await get_or_create_webhook(webhook_channel)
-        await move_message_via_webhook(
+        await move_message(
             self.bot, webhook, self.message, self.executor, thread=thread
         )
         await interaction.edit_original_response(
@@ -236,7 +236,7 @@ class HelpPostTitle(SafeModal, title="Turn into #help post"):
         await interaction.response.defer(ephemeral=True, thinking=True)
 
         webhook = await get_or_create_webhook(self.bot.help_channel)
-        msg = await move_message_via_webhook(
+        msg = await move_message(
             self.bot,
             webhook,
             self._message,

--- a/app/components/zig_codeblocks.py
+++ b/app/components/zig_codeblocks.py
@@ -24,7 +24,7 @@ from app.common.hooks import (
     create_edit_hook,
     remove_view_after_delay,
 )
-from app.common.message_moving import get_or_create_webhook, move_message_via_webhook
+from app.common.message_moving import get_or_create_webhook, move_message
 
 if TYPE_CHECKING:
     from collections.abc import Collection
@@ -99,7 +99,7 @@ class CodeblockActions(ItemActions):
 
         webhook = await get_or_create_webhook(webhook_channel)
         self.message.content = self._replaced_message_content
-        await move_message_via_webhook(
+        await move_message(
             self.bot, webhook, self.message, thread=thread, include_move_marks=False
         )
 


### PR DESCRIPTION
I do not see any point to specifying that it uses a webhook to move the message when you already pass the webhook as a parameter. If this change isn't considered desirable, feel free to close the PR.