### PR TITLE
fix: allow for capital letters in repos + orgs 

### DIFF
--- a/app/components/github_integration/code_links.py
+++ b/app/components/github_integration/code_links.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from app.bot import GhosttyBot
 
 CODE_LINK_PATTERN = re.compile(
-    r"https?://(?:www\.)?github\.com/([a-z0-9\-]+)/([a-z0-9\-\._]+)/blob/"
+    r"https?://(?:www\.)?github\.com/([a-zA-Z0-9\-]+)/([a-zA-Z0-9\-\._]+)/blob/"
     r"([^/\s]+)/([^\?#\s]+)(?:[^\#\s]*)?#L(\d+)(?:C\d+)?(?:-L(\d+)(?:C\d+)?)?"
 )
 LANG_SUBSTITUTIONS = {

--- a/app/components/github_integration/comments/fetching.py
+++ b/app/components/github_integration/comments/fetching.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
     from pydantic import BaseModel
 
 COMMENT_PATTERN = re.compile(
-    r"https?://(?:www\.)?github\.com/([a-z0-9\-]+)/([a-z0-9\-\._]+)/"
+    r"https?://(?:www\.)?github\.com/([a-zA-Z0-9\-]+)/([a-zA-Z0-9\-\._]+)/"
     r"(issues|discussions|pull)/(\d+)/?#(\w+?-?)(\d+)"
 )
 STATE_TO_COLOR = {


### PR DESCRIPTION
Requires #340 to be merged in first

Before, <https://github.com/Nix OS/nixpkgs/pull/435835#event-19551251684> (space added to not have this show up on that issue :p)
wouldn't trigger anything on the bot because `NixOS` has capital letters.

While there are still some valid URLs that are not captured by this
regex, they are things like <https://github.com/>. I think it is safe to
assume that this is highly unlikely to happen nor be an issue (perhaps a
secret way to send a link without waking up the bot)