### PR TITLE
Remove redundant affixes

### DIFF
--- a/app/components/activity_status.py
+++ b/app/components/activity_status.py
@@ -24,18 +24,18 @@ STATUSES = (
 class ActivityStatus(commands.Cog):
     def __init__(self, bot: GhosttyBot) -> None:
         self.bot = bot
-        self.randomize_activity_status.start()
+        self.randomize.start()
 
     @override
     async def cog_unload(self) -> None:
-        self.randomize_activity_status.cancel()
+        self.randomize.cancel()
 
     @tasks.loop(hours=2)
-    async def randomize_activity_status(self) -> None:
+    async def randomize(self) -> None:
         await self.bot.change_presence(activity=secrets.choice(STATUSES))
 
-    @randomize_activity_status.before_loop
-    async def before_randomize_activity_status(self) -> None:
+    @randomize.before_loop
+    async def before_randomize(self) -> None:
         await self.bot.wait_until_ready()
 
 

--- a/app/components/github_integration/__init__.py
+++ b/app/components/github_integration/__init__.py
@@ -4,9 +4,9 @@ import asyncio
 from typing import TYPE_CHECKING
 
 from .code_links import CodeLinks
-from .comments import CommentIntegration
+from .comments import Comments
 from .commits import Commits
-from .mentions import MentionIntegration
+from .mentions import Mentions
 from .mentions import fmt as fmt
 from .webhooks import Discussions, Issues, PRHook, monalisten_client
 from app.errors import handle_task_error
@@ -22,8 +22,8 @@ async def setup(bot: GhosttyBot) -> None:
         bot.add_cog(PRHook(bot, monalisten_client)),
         bot.add_cog(Commits(bot, monalisten_client)),
         bot.add_cog(CodeLinks(bot)),
-        bot.add_cog(MentionIntegration(bot)),
-        bot.add_cog(CommentIntegration(bot)),
+        bot.add_cog(Mentions(bot)),
+        bot.add_cog(Comments(bot)),
     )
 
     # Creating a strong reference

--- a/app/components/github_integration/comments/__init__.py
+++ b/app/components/github_integration/comments/__init__.py
@@ -1,3 +1,3 @@
-from .integration import CommentIntegration
+from .integration import Comments
 
-__all__ = ("CommentIntegration",)
+__all__ = ("Comments",)

--- a/app/components/github_integration/comments/integration.py
+++ b/app/components/github_integration/comments/integration.py
@@ -41,7 +41,7 @@ class CommentActions(ItemActions):
 
 
 @final
-class CommentIntegration(commands.Cog):
+class Comments(commands.Cog):
     def __init__(self, bot: GhosttyBot) -> None:
         self.bot = bot
         self.linker = MessageLinker()

--- a/app/components/github_integration/mentions/__init__.py
+++ b/app/components/github_integration/mentions/__init__.py
@@ -1,3 +1,3 @@
-from .integration import MentionIntegration
+from .integration import Mentions
 
-__all__ = ("MentionIntegration",)
+__all__ = ("Mentions",)

--- a/app/components/github_integration/mentions/integration.py
+++ b/app/components/github_integration/mentions/integration.py
@@ -37,7 +37,7 @@ class MentionActions(ItemActions):
 
 
 @final
-class MentionIntegration(commands.Cog):
+class Mentions(commands.Cog):
     def __init__(self, bot: GhosttyBot) -> None:
         self.bot = bot
         self.linker = MessageLinker()

--- a/app/components/message_filter.py
+++ b/app/components/message_filter.py
@@ -58,8 +58,8 @@ class MessageFilter(commands.Cog):
             ),
         )
 
-    @commands.Cog.listener("on_message")
-    async def check_message_filters(self, message: dc.Message) -> None:
+    @commands.Cog.listener()
+    async def on_message(self, message: dc.Message) -> None:
         if message.author == self.bot.user:
             return
         for msg_filter in self.message_filters:


### PR DESCRIPTION
Follow-up to #340.

`CodeLinks.code_linker` ⇒ `CodeLinks.linker`, and other similar renames.