### PR TITLE
Support `removed_from_merge_queue`

### DIFF
--- a/app/components/github_integration/comments/fetching.py
+++ b/app/components/github_integration/comments/fetching.py
@@ -97,6 +97,7 @@ SUPPORTED_EVENTS: dict[str, str | Callable[[IssueEvent], str]] = {
         }~~ {escape_special(rename.to)}"
     ),
     "added_to_merge_queue": "Added this pull request to the merge queue",
+    "removed_from_merge_queue": "Removed this pull request from the merge queue",
     "deployed": lambda event: (
         "Deployed this" + f" via {escape_special(event.performed_via_github_app.name)}"
         if event.performed_via_github_app is not None


### PR DESCRIPTION
Example: `https://github.com/google-gemini/gemini-cli/pull/4625#event-19668902591` (inline code to avoid spamming their issue tracker).