### PR TITLE
Ignore bot messages when checking if a post is to be locked.

### DIFF
--- a/app/components/lock_old_posts.py
+++ b/app/components/lock_old_posts.py
@@ -25,7 +25,8 @@ class LockOldPosts(commands.Cog):
         one_month_ago = now - dt.timedelta(days=30)
 
         if (
-            not isinstance(post, dc.Thread)
+            message.author.bot
+            or not isinstance(post, dc.Thread)
             or not post.parent
             or post.parent.id != self.bot.config.help_channel_id
             or post.locked


### PR DESCRIPTION
Since it takes a few seconds for the post to actually be locked, the bot ends up replying to its own “open a new thread” message with another “open a new thread” message, as seen here: https://discord.com/channels/1005603569187160125/1398875640198987816/1417809020827471894.