### PR TITLE
feat: add sentry tracing

### DIFF
--- a/app/errors.py
+++ b/app/errors.py
@@ -4,16 +4,9 @@ from typing import Any, override
 
 import discord as dc
 from loguru import logger
-from sentry_sdk import capture_exception
-
-from app.config import config
 
 
 def handle_error(error: BaseException) -> None:
-    if config.sentry_dsn is not None:
-        logger.debug("capturing error with sentry")
-        capture_exception(error)
-        return
     logger.exception(error)
     for note in getattr(error, "__notes__", []):
         logger.error(note)

--- a/app/log.py
+++ b/app/log.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, override
 
 import sentry_sdk
 from loguru import logger
+from sentry_sdk.integrations.asyncio import AsyncioIntegration
 
 if TYPE_CHECKING:
     from app.config import Config
@@ -60,6 +61,9 @@ def setup(config: Config) -> None:
         logger.info("initializing sentry")
         sentry_sdk.init(
             dsn=config.sentry_dsn.get_secret_value(),
+            enable_logs=True,
             traces_sample_rate=1.0,
             profiles_sample_rate=1.0,
+            profile_lifecycle="trace",
+            integrations=[AsyncioIntegration()],
         )

--- a/uv.lock
+++ b/uv.lock
@@ -660,15 +660,15 @@ wheels = [
 
 [[package]]
 name = "sentry-sdk"
-version = "2.36.0"
+version = "2.38.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/ac/52fcbba981793d3c90807b79cf6fa130cd25a54d152e653da3ed6d5defef/sentry_sdk-2.36.0.tar.gz", hash = "sha256:af9260e8155e41e8217615a453828e98aa40740865ac4b16b1ccb6a63b4b2e31", size = 343655, upload-time = "2025-09-04T07:56:37.688Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/22/60fd703b34d94d216b2387e048ac82de3e86b63bc28869fb076f8bb0204a/sentry_sdk-2.38.0.tar.gz", hash = "sha256:792d2af45e167e2f8a3347143f525b9b6bac6f058fb2014720b40b84ccbeb985", size = 348116, upload-time = "2025-09-15T15:00:37.846Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/17/41ea723cb40f036d699cd954e2894fe7a044b0fd9a0e6bd881b1c9dda14e/sentry_sdk-2.36.0-py2.py3-none-any.whl", hash = "sha256:0f95586a141068d215376e5bf8ebd279e126f7f42805e9570190ef82a7e232b3", size = 364905, upload-time = "2025-09-04T07:56:36.159Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/84/bde4c4bbb269b71bc09316af8eb00da91f67814d40337cc12ef9c8742541/sentry_sdk-2.38.0-py2.py3-none-any.whl", hash = "sha256:2324aea8573a3fa1576df7fb4d65c4eb8d9929c8fa5939647397a07179eef8d0", size = 370346, upload-time = "2025-09-15T15:00:35.821Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR is based off of #347 and assumes it gets merged.

This PR improves the sentry integration.

Changes:

* remove the explicit capture exception. Default behavior is to path consume exceptions from the logs
* Add asyncio integration, letting us capture errors from async tasks. 
* Add transaction and span (see photo)
* Add tracing to help post scanning because it has been the most troublesome operation. 

<img width="1974" height="1132" alt="image" src="https://github.com/user-attachments/assets/d104831d-20ff-49b7-a401-750620aae6a5" />

> [!NOTE]
> Tested with a DSN and without. Everything works as expected.