### PR TITLE
fix: loaded emoji race condition

### DIFF
--- a/app/bot.py
+++ b/app/bot.py
@@ -73,10 +73,10 @@ class GhosttyBot(commands.Bot):
 
     async def on_ready(self) -> None:
         self.bot_status.last_login_time = dt.datetime.now(tz=dt.UTC)
-        await self._load_emojis()
+        await self.load_emojis()
         logger.info("logged in as {}", self.user)
 
-    async def _load_emojis(self) -> None:
+    async def load_emojis(self) -> None:
         valid_emoji_names = frozenset(get_args(EmojiName))
 
         for emoji in self.ghostty_guild.emojis:

--- a/app/components/github_integration/commits.py
+++ b/app/components/github_integration/commits.py
@@ -132,6 +132,8 @@ class Commits(commands.Cog):
         # Pass a commit mention of the current commit back to the bot's status
         # functionality for display.
         if commit_url := self.bot.bot_status.commit_url:
+            # Avoid race condition with bot.py on_ready, by forcing emojis to be loaded.
+            await self.bot.load_emojis()
             fake_message = cast("dc.Message", SimpleNamespace(content=commit_url))
             if (links := await self.process(fake_message)).item_count:
                 self.bot.bot_status.commit_data = links.content


### PR DESCRIPTION
Fixes #373

Call to load emojis in two places, ensuring that the emojis will be loaded when needed.