### PR TITLE
test: use the already installed anyio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ dev = [
   "basedpyright==1.31.4",
   "taplo==0.9.3",
   "pytest==8.4.1",
-  "pytest-asyncio==1.1.0",
   "hypothesis==6.138.16",
+  "anyio==4.11.0",
 ]
 
 [tool.pyright]
@@ -41,8 +41,8 @@ reportUnknownLambdaType = false
 
 [tool.pytest.ini_options]
 pythonpath = "."
+anyio_mode = "auto"
 filterwarnings = ["ignore::Warning"]
-asyncio_default_fixture_loop_scope = "function"
 
 [tool.ruff.lint]
 select = ["ALL"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,10 @@
+import pytest
+
 from tests.fixtures.hooks import edit_hook, linker
 
 __all__ = ("edit_hook", "linker")
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"

--- a/tests/hooks/test_delete_hook.py
+++ b/tests/hooks/test_delete_hook.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
     from app.common.linker import MessageLinker
 
 
-@pytest.mark.asyncio
 async def test_original_delete(linker: MessageLinker) -> None:
     msg = spawn_user_message()
     reply = cast("Mock", spawn_bot_message())
@@ -27,7 +26,6 @@ async def test_original_delete(linker: MessageLinker) -> None:
     assert not linker.refs
 
 
-@pytest.mark.asyncio
 async def test_original_delete_frozen(linker: MessageLinker) -> None:
     msg = spawn_user_message()
     reply = cast("Mock", spawn_bot_message())
@@ -42,7 +40,6 @@ async def test_original_delete_frozen(linker: MessageLinker) -> None:
 
 
 @pytest.mark.parametrize("freeze", [True, False])
-@pytest.mark.asyncio
 async def test_original_delete_not_linked(linker: MessageLinker, freeze: bool) -> None:
     msg = spawn_user_message()
     if freeze:
@@ -54,7 +51,6 @@ async def test_original_delete_not_linked(linker: MessageLinker, freeze: bool) -
     assert not linker.is_frozen(msg)
 
 
-@pytest.mark.asyncio
 async def test_original_delete_expired(linker: MessageLinker) -> None:
     msg = spawn_user_message(age=dt.timedelta(days=2))
     reply = cast("Mock", spawn_bot_message())
@@ -66,7 +62,6 @@ async def test_original_delete_expired(linker: MessageLinker) -> None:
     assert not linker.refs
 
 
-@pytest.mark.asyncio
 async def test_reply_delete(linker: MessageLinker) -> None:
     msg = spawn_user_message()
     reply = spawn_bot_message()
@@ -79,7 +74,6 @@ async def test_reply_delete(linker: MessageLinker) -> None:
     assert not linker.is_frozen(msg)
 
 
-@pytest.mark.asyncio
 async def test_bot_not_linked_delete(linker: MessageLinker) -> None:
     msg = spawn_bot_message()
     linker.freeze(msg)

--- a/tests/hooks/test_edit_hook.py
+++ b/tests/hooks/test_edit_hook.py
@@ -3,20 +3,19 @@ from __future__ import annotations
 import datetime as dt
 from typing import TYPE_CHECKING, cast
 
-import pytest
-
 from tests.fixtures.hooks import TrackedCallable
 from tests.hooks.utils import spawn_message
 
 if TYPE_CHECKING:
     from unittest.mock import Mock
 
+    import pytest
+
     from tests.fixtures.hooks import EditHook
 
     from app.common.linker import MessageLinker
 
 
-@pytest.mark.asyncio
 async def test_same_content(linker: MessageLinker, edit_hook: EditHook) -> None:
     msg = spawn_message(content="foo")
     msg2 = spawn_message(content="foo")
@@ -26,7 +25,6 @@ async def test_same_content(linker: MessageLinker, edit_hook: EditHook) -> None:
     assert not linker.is_expired.called
 
 
-@pytest.mark.asyncio
 async def test_message_expired(linker: MessageLinker, edit_hook: EditHook) -> None:
     msg = spawn_message(content="foo", age=dt.timedelta(days=2))
     msg2 = spawn_message(content="bar")
@@ -39,7 +37,6 @@ async def test_message_expired(linker: MessageLinker, edit_hook: EditHook) -> No
     assert not linker.refs
 
 
-@pytest.mark.asyncio
 async def test_different_content_same_items(
     linker: MessageLinker, edit_hook: EditHook
 ) -> None:
@@ -52,7 +49,6 @@ async def test_different_content_same_items(
     assert not linker.get.called
 
 
-@pytest.mark.asyncio
 async def test_different_items_unlinked_frozen(
     linker: MessageLinker, edit_hook: EditHook
 ) -> None:
@@ -67,7 +63,6 @@ async def test_different_items_unlinked_frozen(
     assert linker.is_expired.calls == 1
 
 
-@pytest.mark.asyncio
 async def test_different_items_unlinked_prior(
     linker: MessageLinker, edit_hook: EditHook
 ) -> None:
@@ -81,7 +76,6 @@ async def test_different_items_unlinked_prior(
     assert not edit_hook.interactor.called
 
 
-@pytest.mark.asyncio
 async def test_new_items_edited_in(
     linker: MessageLinker, edit_hook: EditHook, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -96,7 +90,6 @@ async def test_new_items_edited_in(
     assert edit_hook.interactor.called
 
 
-@pytest.mark.asyncio
 async def test_different_items_linked_frozen(
     linker: MessageLinker, edit_hook: EditHook
 ) -> None:
@@ -113,7 +106,6 @@ async def test_different_items_linked_frozen(
     assert linker.is_frozen.calls == 1
 
 
-@pytest.mark.asyncio
 async def test_items_edited_out(linker: MessageLinker, edit_hook: EditHook) -> None:
     msg = spawn_message(content="foo 1")
     msg2 = spawn_message(content="foo")
@@ -126,7 +118,6 @@ async def test_items_edited_out(linker: MessageLinker, edit_hook: EditHook) -> N
     assert reply.delete.called
 
 
-@pytest.mark.asyncio
 async def test_items_edited(linker: MessageLinker, edit_hook: EditHook) -> None:
     msg = spawn_message(content="foo 1")
     msg2 = spawn_message(content="foo 2")

--- a/tests/test_close_help_post.py
+++ b/tests/test_close_help_post.py
@@ -68,7 +68,6 @@ emojis = cast(
     ("entity_id", "kind"),
     [(189, "Issue"), (1234, "Pull Request"), (2354, "Discussion")],
 )
-@pytest.mark.asyncio
 async def test_mention_entity(
     entity_id: int,
     kind: str,
@@ -85,7 +84,6 @@ async def test_mention_entity(
 
 
 @pytest.mark.parametrize("entity_id", [-13, 1023, 8192])
-@pytest.mark.asyncio
 async def test_mention_missing_entity(
     entity_id: int, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -125,7 +125,6 @@ def test_post_is_not_solved(names: list[str]) -> None:
 
 
 @given(st.lists(st.from_type(type)), st.integers())
-@pytest.mark.asyncio
 async def test_aenumerate[T](items: list[T], start: int) -> None:
     async def async_iterator() -> AsyncGenerator[T]:
         for item in items:
@@ -209,7 +208,6 @@ def test_dynamic_timestamp(dt: dt.datetime, fmt: str | None, result: str) -> Non
     assert dynamic_timestamp(dt, fmt) == result
 
 
-@pytest.mark.asyncio
 async def test_suppress_embeds_after_delay() -> None:
     suppressed = False
 
@@ -302,14 +300,12 @@ def test_format_or_file_long_template_transform() -> None:
         ("import sys; print('Hello, world!', file=sys.stderr)", ""),
     ],
 )
-@pytest.mark.asyncio
 async def test_async_process_check_output_succeeds(code: str, output: str) -> None:
     stdout = await async_process_check_output(sys.executable, "-c", code)
     assert stdout == output
 
 
 @pytest.mark.skipif(not sys.executable, reason="cannot find python interpreter path")
-@pytest.mark.asyncio
 async def test_async_process_check_output_fails() -> None:
     with pytest.raises(subprocess.CalledProcessError):
         await async_process_check_output(
@@ -317,7 +313,6 @@ async def test_async_process_check_output_fails() -> None:
         )
 
 
-@pytest.mark.asyncio
 async def test_async_process_check_output_invalid_argument() -> None:
     with pytest.raises(ValueError, match="stdout argument not allowed"):
         await async_process_check_output("", stdout=subprocess.DEVNULL)

--- a/uv.lock
+++ b/uv.lock
@@ -68,15 +68,15 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.10.0"
+version = "4.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
     { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f1/b4/636b3b65173d3ce9a38ef5f0522789614e590dab6a8d505340a4efe4c567/anyio-4.10.0.tar.gz", hash = "sha256:3f3fae35c96039744587aa5b8371e7e8e603c0702999535961dd336026973ba6", size = 213252, upload-time = "2025-08-04T08:54:26.451Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/78/7d432127c41b50bccba979505f272c16cbcadcc33645d5fa3a738110ae75/anyio-4.11.0.tar.gz", hash = "sha256:82a8d0b81e318cc5ce71a5f1f8b5c4e63619620b63141ef8c995fa0db95a57c4", size = 219094, upload-time = "2025-09-23T09:19:12.58Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/12/e5e0282d673bb9746bacfb6e2dba8719989d3660cdb2ea79aee9a9651afb/anyio-4.10.0-py3-none-any.whl", hash = "sha256:60e474ac86736bbfd6f210f7a61218939c318f43f9972497381f1c5e930ed3d1", size = 107213, upload-time = "2025-08-04T08:54:24.882Z" },
+    { url = "https://files.pythonhosted.org/packages/15/b3/9b1a8074496371342ec1e796a96f99c82c945a339cd81a8e73de28b4cf9e/anyio-4.11.0-py3-none-any.whl", hash = "sha256:0287e96f4d26d4149305414d4e3bc32f0dcd0862365a4bddea19d7a1ec38c4fc", size = 109097, upload-time = "2025-09-23T09:19:10.601Z" },
 ]
 
 [[package]]
@@ -248,10 +248,10 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "anyio" },
     { name = "basedpyright" },
     { name = "hypothesis" },
     { name = "pytest" },
-    { name = "pytest-asyncio" },
     { name = "ruff" },
     { name = "taplo" },
 ]
@@ -271,10 +271,10 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "anyio", specifier = "==4.11.0" },
     { name = "basedpyright", specifier = "==1.31.4" },
     { name = "hypothesis", specifier = "==6.138.16" },
     { name = "pytest", specifier = "==8.4.1" },
-    { name = "pytest-asyncio", specifier = "==1.1.0" },
     { name = "ruff", specifier = "==0.13.0" },
     { name = "taplo", specifier = "==0.9.3" },
 ]
@@ -609,18 +609,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
-]
-
-[[package]]
-name = "pytest-asyncio"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/51/f8794af39eeb870e87a8c8068642fc07bce0c854d6865d7dd0f2a9d338c2/pytest_asyncio-1.1.0.tar.gz", hash = "sha256:796aa822981e01b68c12e4827b8697108f7205020f24b5793b3c41555dab68ea", size = 46652, upload-time = "2025-07-16T04:29:26.393Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/9d/bf86eddabf8c6c9cb1ea9a869d6873b46f105a5d292d3a6f7071f5b07935/pytest_asyncio-1.1.0-py3-none-any.whl", hash = "sha256:5fe2d69607b0bd75c656d1211f969cadba035030156745ee09e7d71740e58ecf", size = 15157, upload-time = "2025-07-16T04:29:24.929Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR is one you can dismiss, as the justification is thin at best. 

`githubkit` already defines `anyio` as a dependency. So there is no need to _also_ have the `pytest-asyncio` plugin. We can simplify dependencies by removing this.

`anyio_mode = "auto"` allows us to remove the `@pytest.mark.asyncio`. This type of setup can also be done in the pytest plugin, but wasn't. Similarly, `@pytest.mark.anyio` does exist if you want to keep the previous behavior. 