### PR TITLE
feat: auto cleanup webhooks

### DIFF
--- a/app/components/github_integration/webhooks/commits.py
+++ b/app/components/github_integration/webhooks/commits.py
@@ -41,4 +41,5 @@ def register_hooks(bot: GhosttyBot, monalisten_client: Monalisten) -> None:
                 event.comment.body,
             ),
             Footer("commit", f"Commit {sha}: {commit_title}"),
+            origin_repo=event.repository,
         )

--- a/app/components/github_integration/webhooks/discussions.py
+++ b/app/components/github_integration/webhooks/discussions.py
@@ -65,6 +65,7 @@ def register_hooks(bot: GhosttyBot, webhook: Monalisten) -> None:
             discussion_footer(discussion, emoji="discussion"),
             color="gray",
             feed_type="discussions",
+            origin_repo=event.repository,
         )
 
     @webhook.event.discussion.closed
@@ -106,6 +107,7 @@ def register_hooks(bot: GhosttyBot, webhook: Monalisten) -> None:
             discussion_footer(discussion, emoji="discussion_answered"),
             color="green",
             feed_type="discussions",
+            origin_repo=event.repository,
         )
 
     @webhook.event.discussion.unanswered
@@ -177,4 +179,5 @@ def register_hooks(bot: GhosttyBot, webhook: Monalisten) -> None:
             discussion_embed_content(discussion, "commented on", event.comment.body),
             discussion_footer(discussion),
             feed_type="discussions",
+            origin_repo=event.repository,
         )

--- a/app/components/github_integration/webhooks/issues.py
+++ b/app/components/github_integration/webhooks/issues.py
@@ -18,14 +18,13 @@ if TYPE_CHECKING:
 
     from app.bot import EmojiName, GhosttyBot
 
-
-DISUCSSION_DIV_TAG = re.compile(
+DISCUSSION_DIV_TAG = re.compile(
     r"\s*<div type='discussions-op-text'>((?:.|\s)*?)\s*</div>\s*", re.MULTILINE
 )
 
 
 def remove_discussion_div(body: str | None) -> str | None:
-    return body and DISUCSSION_DIV_TAG.sub(r"\g<1>", body)
+    return body and DISCUSSION_DIV_TAG.sub(r"\g<1>", body)
 
 
 class IssueLike(Protocol):

--- a/app/components/github_integration/webhooks/issues.py
+++ b/app/components/github_integration/webhooks/issues.py
@@ -25,7 +25,7 @@ DISUCSSION_DIV_TAG = re.compile(
 
 
 def remove_discussion_div(body: str | None) -> str | None:
-    return DISUCSSION_DIV_TAG.sub(r"\g<1>", body) if body else body
+    return body and DISUCSSION_DIV_TAG.sub(r"\g<1>", body)
 
 
 class IssueLike(Protocol):

--- a/app/components/github_integration/webhooks/prs.py
+++ b/app/components/github_integration/webhooks/prs.py
@@ -58,6 +58,7 @@ def register_hooks(bot: GhosttyBot, webhook: Monalisten) -> None:  # noqa: PLR09
             pr_embed_content(pr, "opened {}", pr.body),
             pr_footer(pr, emoji="pull_open"),
             color="green",
+            origin_repo=event.repository,
         )
 
     @webhook.event.pull_request.closed
@@ -70,6 +71,7 @@ def register_hooks(bot: GhosttyBot, webhook: Monalisten) -> None:  # noqa: PLR09
             pr_embed_content(pr, f"{action} {{}}"),
             pr_footer(pr, emoji="pull_" + action),
             color=color,
+            origin_repo=event.repository,
         )
 
     @webhook.event.pull_request.reopened
@@ -154,6 +156,7 @@ def register_hooks(bot: GhosttyBot, webhook: Monalisten) -> None:  # noqa: PLR09
             event.sender,
             pr_embed_content(pr, "removed review request for {}", content),
             pr_footer(pr),
+            origin_repo=event.repository,
         )
 
     @webhook.event.pull_request_review.submitted
@@ -186,6 +189,7 @@ def register_hooks(bot: GhosttyBot, webhook: Monalisten) -> None:  # noqa: PLR09
             EmbedContent(f"{title} PR #{pr.number}", review.html_url, review.body),
             pr_footer(pr, emoji=emoji),
             color=color,
+            origin_repo=event.repository,
         )
 
     @webhook.event.pull_request_review.dismissed
@@ -227,6 +231,7 @@ def register_hooks(bot: GhosttyBot, webhook: Monalisten) -> None:  # noqa: PLR09
                 content,
             ),
             pr_footer(pr, from_review=True),
+            origin_repo=event.repository,
         )
 
 

--- a/app/components/github_integration/webhooks/utils.py
+++ b/app/components/github_integration/webhooks/utils.py
@@ -143,10 +143,8 @@ async def send_edit_difference(
 def _shorten_same_repo_links(
     origin_repo: RepositoryWebhooks, matchobj: re.Match[str]
 ) -> str:
-    if (
-        matchobj.group("owner") == origin_repo.owner.name
-        and matchobj.group("repo") == origin_repo.name
-    ):
+    owner, _, repo = origin_repo.full_name.partition("/")
+    if matchobj["owner"] == owner and matchobj["repo"] == repo:
         # Only short hand if link comes from same repo
         return f"[#{matchobj.group('number')}]({matchobj.group()})"
     return matchobj.group()

--- a/app/components/github_integration/webhooks/utils.py
+++ b/app/components/github_integration/webhooks/utils.py
@@ -85,7 +85,7 @@ class FooterGenerator(Protocol):
 
 
 def _convert_codeblock(match: re.Match[str]) -> str:
-    return "\u2035" * len(match.group())
+    return "\u2035" * len(match[0])
 
 
 async def send_edit_difference(
@@ -146,8 +146,8 @@ def _shorten_same_repo_links(
     owner, _, repo = origin_repo.full_name.partition("/")
     if matchobj["owner"] == owner and matchobj["repo"] == repo:
         # Only short hand if link comes from same repo
-        return f"[#{matchobj.group('number')}]({matchobj.group()})"
-    return matchobj.group()
+        return f"[#{matchobj['number']}]({matchobj[0]})"
+    return matchobj[0]
 
 
 async def send_embed(  # noqa: PLR0913


### PR DESCRIPTION
Closes #387 

This PR cleans up embeds sent from webhook logic. This handles the `<sup>` and `<sub>` tags and shortens long GH links into hyperlinks, when possible and logical. This **does not** convert things like `#123` into a hyperlink.

Created issues might also have `div` tags that should be removed. A tag that comes from converting a discussion into an issue. It just takes up space that we can ignore on creation. 