### PR TITLE
Make zero item count check in commit links more consistent

### DIFF
--- a/app/components/github_integration/commit_links.py
+++ b/app/components/github_integration/commit_links.py
@@ -132,6 +132,7 @@ class CommitLinks(commands.Cog):
         output = await self.process(message)
         if not output.item_count:
             return
+        await message.edit(suppress=True)
         reply = await message.reply(
             output.content,
             mention_author=False,

--- a/app/components/github_integration/commit_links.py
+++ b/app/components/github_integration/commit_links.py
@@ -130,7 +130,7 @@ class CommitLinks(commands.Cog):
         if message.author.bot or self.bot.fails_message_filters(message):
             return
         output = await self.process(message)
-        if output.item_count == 0:
+        if not output.item_count:
             return
         reply = await message.reply(
             output.content,


### PR DESCRIPTION
It's `not` everywhere else (e.g. `zig_codeblocks`, entity mentions). Also adds a missing first suppress.