### PR TITLE
fix: don't send a diff block for an empty hunk

### DIFF
--- a/app/components/github_integration/webhooks/prs.py
+++ b/app/components/github_integration/webhooks/prs.py
@@ -218,10 +218,8 @@ def register_hooks(bot: GhosttyBot, webhook: Monalisten) -> None:  # noqa: PLR09
         pr, content = event.pull_request, event.comment.body
 
         hunk = _reduce_diff_hunk(event.comment.diff_hunk)
-        if hunk.strip() and (
-            500 - len(content) - len(hunk) - HUNK_CODEBLOCK_OVERHEAD >= 0
-        ):
-            # We can fit a hunk!
+        hunk_can_fit = 500 - len(content) - len(hunk) - HUNK_CODEBLOCK_OVERHEAD >= 0
+        if hunk.strip() and hunk_can_fit:
             content = f"```diff\n{hunk}\n```\n{content}"
 
         await send_embed(


### PR DESCRIPTION
Should resolve the bug where an empty diff codeblock is sent when the hunk is empty:

<img width="618" height="282" alt="image" src="https://github.com/user-attachments/assets/9cbd3804-93de-4e1d-9404-9530426a9fc7" />
