### PR TITLE
feat: remove the diff header

### DIFF
--- a/app/components/github_integration/webhooks/utils.py
+++ b/app/components/github_integration/webhooks/utils.py
@@ -115,15 +115,9 @@ async def send_edit_difference(
             if event_object.body
             else ""
         )
-        diff = "".join(
-            difflib.unified_diff(
-                from_file,
-                to_file,
-                fromfile=changes.title.from_ if changes.title else event_object.title,
-                tofile=event_object.title,
-                tofiledate=event_object.updated_at.isoformat(),
-            )
-        )
+        # Skip the header 3 lines. All of that info is duplicated in other locations of
+        # the embed.
+        diff = "".join(list(difflib.unified_diff(from_file, to_file))[3:])
         diff = truncate(diff, 500 - len("```diff\n\n```"))
         content = f"```diff\n{diff}\n```"
     elif changes.title:


### PR DESCRIPTION
At a max size of 500, the diffs are really small. Modifying all the logic required to special case diffs to have a larger limit, is complicated. A quick win, would be to remove the header. 
```diff
--- font(fix): Extract and apply Nerd Font codepoint mapping table
+++ font(fix): Extract and apply Nerd Font codepoint mapping table    2025-10-11T10:15:28+00:00
@@ -8,6 +8,6 @@
```

These top three lines consume a large amount of the 500 characters. And all the data is duplicate. The title can't be different here. And the time is the time the message was sent. Technically, they can differ. But that level of precision is not needed. If you really need to know the exact time, you can go onto GH. 