### PR TITLE
chore: remove bsky embed replacement

### DIFF
--- a/app/components/fixup_embeds.py
+++ b/app/components/fixup_embeds.py
@@ -35,13 +35,6 @@ EMBED_SITES: tuple[SiteTransformation, ...] = (
     ),
     (
         re.compile(
-            r"https://(?:www\.)?bsky\.app/"
-            rf"(profile/{VALID_URI_CHARS}+/post/{VALID_URI_CHARS}+)"
-        ),
-        lambda match: f"https://fxbsky.app/{match[1]}",
-    ),
-    (
-        re.compile(
             rf"https://(?:www\.)?pixiv\.net/({VALID_URI_CHARS}+/{VALID_URI_CHARS}+)"
         ),
         lambda match: f"https://phixiv.net/{match[1]}",


### PR DESCRIPTION
As brought up by @oshdubh, the default bluesky embed is actually really good. There is no need to replace it since they do a killer job.

But if that is not reason enough, the default endpoint does a better job with some embeds:

<img width="906" height="595" alt="image" src="https://github.com/user-attachments/assets/534bbe9c-bc8e-48cf-9b15-0b84b761f2a4" />
