### PR TITLE
webhook: consider drafts for `pull_request.opened` events

### DIFF
--- a/app/components/github_integration/webhooks/prs.py
+++ b/app/components/github_integration/webhooks/prs.py
@@ -56,7 +56,7 @@ def register_hooks(bot: GhosttyBot, webhook: Monalisten) -> None:  # noqa: PLR09
             bot,
             event.sender,
             pr_embed_content(pr, "opened {}", pr.body),
-            pr_footer(pr, emoji="pull_open"),
+            pr_footer(pr),
             color="green",
             origin_repo=event.repository,
         )


### PR DESCRIPTION
Right now any opened draft PR still uses the `pull_open` emoji. This PR fixes this.