### PR TITLE
Make message filter's first message silent instead of content message

### DIFF
--- a/app/components/message_filter.py
+++ b/app/components/message_filter.py
@@ -85,11 +85,11 @@ class MessageFilter(commands.Cog):
         )
         if message.content:
             notification += _MESSAGE_CONTENT_NOTICE
-        await try_dm(message.author, notification, silent=bool(message.content))
+        await try_dm(message.author, notification)
 
         if message.content:
             content, file = format_or_file(message.content)
-            await try_dm(message.author, content, file=file)
+            await try_dm(message.author, content, file=file, silent=True)
             await try_dm(message.author, _COPY_TEXT_HINT, silent=True)
 
 


### PR DESCRIPTION
The notification previously showed the content, e.g. “#1234”, instead of “Hey! Your message in #showcase was deleted…”. Seeing only the content in your notifications is a bit confusing (“why did Ghostty Bot DM me my own message??”, or if you forgot you sent that, “why did Ghostty Bot DM me random crap???”).

#### Old notification:
<img width="480" height="204" alt="Notification from toB yttsohG showing “#1234”." src="https://github.com/user-attachments/assets/392f0476-7c15-4193-a60a-5b4fc0275ed7" />

#### New notification:
<img width="495" height="211" alt="Notification from toB yttsohG showing “Hey! Your message in #showcase was deleted because it did not contain…”." src="https://github.com/user-attachments/assets/cdee56d2-d327-45f3-ae32-2424f396661e" />