### PR TITLE
chore: bump basedpyright version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
 [dependency-groups]
 dev = [
   "ruff==0.14.0",
-  "basedpyright==1.31.6",
+  "basedpyright==1.32.1",
   "taplo==0.9.3",
   "pytest==8.4.2",
   "hypothesis==6.140.3",
@@ -33,7 +33,8 @@ dev = [
   "msgpack-types==0.5",
 ]
 
-[tool.pyright]
+[tool.basedpyright]
+enableBasedFeatures = true
 reportAny = false
 reportExplicitAny = false
 reportImplicitStringConcatenation = false

--- a/uv.lock
+++ b/uv.lock
@@ -192,14 +192,14 @@ wheels = [
 
 [[package]]
 name = "basedpyright"
-version = "1.31.6"
+version = "1.32.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodejs-wheel-binaries" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/f6/c5657b1e464d04757cde2db76922a88091fe16854bd3d12e470c23b0dcf1/basedpyright-1.31.6.tar.gz", hash = "sha256:07f3602ba1582218dfd1db25b8b69cd3493e1f4367f46a44fd57bb9034b52ea9", size = 22683901, upload-time = "2025-10-01T13:11:21.317Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/a5/691d02a30bda15acb6a5727bb696dd7f3fcae1ad5b9f2708020c2645af8c/basedpyright-1.32.1.tar.gz", hash = "sha256:ce979891a3c4649e7c31d665acb06fd451f33fedfd500bc7796ee0950034aa54", size = 22757919, upload-time = "2025-10-23T12:53:28.169Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/2b/34f338b4c04fe965fd209ed872d9fdd893dacc1a06feb6c9fec13ff535c1/basedpyright-1.31.6-py3-none-any.whl", hash = "sha256:620968ee69c14eee6682f29ffd6f813a30966afb1083ecfa4caf155c5d24f2d5", size = 11805295, upload-time = "2025-10-01T13:11:18.308Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d5/17d24fd7ba9d899b82859ee04f4599a1e8a02a85c0753bc15eb3ca7ffff7/basedpyright-1.32.1-py3-none-any.whl", hash = "sha256:06b5cc56693e3690653955e19fbe5d2e38f2a343563b40ef95fd1b10fa556fb6", size = 11841548, upload-time = "2025-10-23T12:53:25.541Z" },
 ]
 
 [[package]]
@@ -351,7 +351,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "anyio", specifier = "==4.11.0" },
-    { name = "basedpyright", specifier = "==1.31.6" },
+    { name = "basedpyright", specifier = "==1.32.1" },
     { name = "hypothesis", specifier = "==6.140.3" },
     { name = "msgpack-types", specifier = "==0.5" },
     { name = "pytest", specifier = "==8.4.2" },


### PR DESCRIPTION
The new version also adds a new option. This option modifies the type system. Currently, there is only one rule that actually utilizes this change. But more will be added in the future. (And that rule isn't hit in this codebase) 

As a note; you should not enable this rule if you are a library. But seeing as this is not a library, it makes sense to enable.

For more details, read https://github.com/DetachHead/basedpyright/releases/tag/v1.32.0 and https://docs.basedpyright.com/v1.32.0/configuration/config-files/#enableBasedFeatures