### PR TITLE
Don't consider snowflakes to be a commit SHA

### DIFF
--- a/app/components/github_integration/commit_links.py
+++ b/app/components/github_integration/commit_links.py
@@ -35,7 +35,8 @@ COMMIT_SHA_PATTERN = re.compile(
         r"(?P<repo>\b[a-z0-9\-\._]+)"
         r"(?P<sep>@|/commit/|/blob/)"
     r")?"
-    r"(?P<sha>[a-f0-9]{7,40})\b",
+    # Ignore SHAs preceded by sequences like <@ or <#, as those are probably snowflakes.
+    r"(?<!<[^a-f0-9\s])(?P<sha>[a-f0-9]{7,40})\b",
     re.IGNORECASE,
 )  # fmt: skip
 


### PR DESCRIPTION
Fixes #444. This does mean things like `<<061a0ae5656c05525aa812f474dee2ed32700125` no longer match, but that's an extremely unlikely case.