### PR TITLE
Avoid passing around an entire GhosttyBot just for emojis

### DIFF
--- a/app/bot.py
+++ b/app/bot.py
@@ -38,6 +38,8 @@ EmojiName = Literal[
     "pull_open",
 ]
 
+type Emojis = MappingProxyType[EmojiName, dc.Emoji]
+
 
 @final
 class GhosttyBot(commands.Bot):
@@ -57,7 +59,7 @@ class GhosttyBot(commands.Bot):
         self.bot_status = BotStatus()
 
         self._ghostty_emojis: dict[EmojiName, dc.Emoji] = {}
-        self.ghostty_emojis = MappingProxyType(self._ghostty_emojis)
+        self.ghostty_emojis: Emojis = MappingProxyType(self._ghostty_emojis)
 
     @override
     async def on_error(self, event_method: str, /, *args: Any, **kwargs: Any) -> None:

--- a/app/components/close_help_post.py
+++ b/app/components/close_help_post.py
@@ -73,9 +73,9 @@ class Close(commands.GroupCog, group_name="close"):
         interaction.extras["error_handled"] = True
 
     async def mention_entity(self, entity_id: int) -> str | None:
+        # Forging a message to use the entity mention logic
         output = await github_entities_fmt.entity_message(
-            self.bot,
-            # Forging a message to use the entity mention logic
+            self.bot.ghostty_emojis,
             cast("dc.Message", SimpleNamespace(content=f"#{entity_id}")),
         )
         return output.content or None

--- a/app/components/github_integration/comments/integration.py
+++ b/app/components/github_integration/comments/integration.py
@@ -46,7 +46,7 @@ class GitHubComments(commands.Cog):
         CommentActions.linker = self.linker
 
     def comment_to_embed(self, comment: Comment) -> dc.Embed:
-        emoji = get_entity_emoji(self.bot, comment.entity)
+        emoji = get_entity_emoji(self.bot.ghostty_emojis, comment.entity)
         title = f"{emoji} {comment.entity.title}"
         formatted_reactions = comment.reactions and [
             f"{REACTION_EMOJIS[reaction]} ×{count}"  # noqa: RUF001

--- a/app/components/github_integration/entities/fmt.py
+++ b/app/components/github_integration/entities/fmt.py
@@ -12,13 +12,13 @@ from toolbox.misc import format_diff_note
 if TYPE_CHECKING:
     import discord as dc
 
-    from app.bot import GhosttyBot
+    from app.bot import Emojis
     from app.components.github_integration.models import Entity
 
 ENTITY_TEMPLATE = "**{entity.kind} [#{entity.number}](<{entity.html_url}>):** {title}"
 
 
-def get_entity_emoji(bot: GhosttyBot, entity: Entity) -> dc.Emoji:
+def get_entity_emoji(emojis: Emojis, entity: Entity) -> dc.Emoji:
     if isinstance(entity, Issue):
         state = "open"
         if entity.closed:
@@ -44,7 +44,7 @@ def get_entity_emoji(bot: GhosttyBot, entity: Entity) -> dc.Emoji:
         msg = f"Unknown entity type: {type(entity)}"
         raise TypeError(msg)
 
-    return bot.ghostty_emojis[emoji_name]
+    return emojis[emoji_name]
 
 
 def _format_entity_detail(entity: Entity) -> str:
@@ -73,7 +73,7 @@ def _format_entity_detail(entity: Entity) -> str:
     return f"-# {body}\n"
 
 
-def _format_mention(bot: GhosttyBot, entity: Entity) -> str:
+def _format_mention(emojis: Emojis, entity: Entity) -> str:
     headline = ENTITY_TEMPLATE.format(entity=entity, title=escape_special(entity.title))
 
     owner, name = entity.owner, entity.repo_name
@@ -85,7 +85,7 @@ def _format_mention(bot: GhosttyBot, entity: Entity) -> str:
     )
     entity_detail = _format_entity_detail(entity)
 
-    emoji = get_entity_emoji(bot, entity)
+    emoji = get_entity_emoji(emojis, entity)
     return f"{emoji} {headline}\n{subtext}{entity_detail}"
 
 
@@ -101,9 +101,9 @@ async def extract_entities(message: dc.Message) -> list[Entity]:
     ]
 
 
-async def entity_message(bot: GhosttyBot, message: dc.Message) -> ProcessedMessage:
+async def entity_message(emojis: Emojis, message: dc.Message) -> ProcessedMessage:
     entities = [
-        _format_mention(bot, entity) for entity in await extract_entities(message)
+        _format_mention(emojis, entity) for entity in await extract_entities(message)
     ]
 
     if len("\n".join(entities)) > 2000:

--- a/app/components/github_integration/entities/integration.py
+++ b/app/components/github_integration/entities/integration.py
@@ -64,7 +64,7 @@ class GitHubEntities(commands.Cog):
             reply = self.linker.get(msg)
             assert reply is not None
 
-            new_output = await entity_message(self.bot, msg)
+            new_output = await entity_message(self.bot.ghostty_emojis, msg)
 
             with safe_edit:
                 await reply.edit(
@@ -84,7 +84,7 @@ class GitHubEntities(commands.Cog):
         if is_dm(message.author):
             return
 
-        output = await entity_message(self.bot, message)
+        output = await entity_message(self.bot.ghostty_emojis, message)
         if not output.item_count:
             return
 
@@ -116,7 +116,7 @@ class GitHubEntities(commands.Cog):
         await self.linker.edit(
             before,
             after,
-            message_processor=partial(entity_message, self.bot),
+            message_processor=partial(entity_message, self.bot.ghostty_emojis),
             interactor=self.reply_with_entities,
             view_type=EntityActions,
         )

--- a/app/components/github_integration/webhooks/utils.py
+++ b/app/components/github_integration/webhooks/utils.py
@@ -15,7 +15,7 @@ from toolbox.misc import truncate
 if TYPE_CHECKING:
     from githubkit.versions.latest.models import RepositoryWebhooks, SimpleUser
 
-    from app.bot import EmojiName, GhosttyBot
+    from app.bot import EmojiName, Emojis, GhosttyBot
     from app.config import WebhookFeedType
 
 CODEBLOCK = re.compile(r"`{3,}")
@@ -71,10 +71,10 @@ class Footer(NamedTuple):
     icon: EmojiName
     text: str
 
-    def dict(self, bot: GhosttyBot) -> dict[str, str | None]:
+    def dict(self, emojis: Emojis) -> dict[str, str | None]:
         return {
             "text": self.text,
-            "icon_url": getattr(bot.ghostty_emojis[self.icon], "url", None),
+            "icon_url": getattr(emojis[self.icon], "url", None),
         }
 
 
@@ -177,7 +177,7 @@ async def send_embed(  # noqa: PLR0913
     embed = (
         dc
         .Embed(color=color and EMBED_COLORS.get(color), **content.dict)
-        .set_footer(**footer.dict(bot))
+        .set_footer(**footer.dict(bot.ghostty_emojis))
         .set_author(**author.model_dump())
     )
     await bot.webhook_channels[feed_type].send(embed=embed)


### PR DESCRIPTION
xref #466.

Follow-up to a6146fb8589fc6a3448e2183700ae096ccc1ac2f, cherry-picked from https://github.com/ghostty-org/discord-bot/pull/441/changes/6ca493c0f6f21fdfb569100decc3d86963971b04 of #441.

This is particularly useful were GitHub integration code to be moved to a separate package in the future; even if not done, requiring the entire bot for emojis is excessive.