### PR TITLE
Make config and gh context variables

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -1,20 +1,24 @@
 import asyncio
 from contextlib import suppress
 
+from githubkit import GitHub
 from loguru import logger
 
 from app import log
 from app.bot import GhosttyBot
-from app.config import config, gh
+from app.config import Config, config, config_var, gh_var
 
 
 async def main() -> None:
-    log.setup(config)
-
-    logger.trace("creating GhosttyBot instance for starting bot")
-    async with GhosttyBot(config, gh) as bot:
-        logger.debug("starting the bot")
-        await bot.start(config.token.get_secret_value())
+    with (
+        config_var.set(Config(".env")),
+        gh_var.set(GitHub(config().github_token.get_secret_value())),
+    ):
+        log.setup()
+        logger.trace("creating GhosttyBot instance for starting bot")
+        async with GhosttyBot() as bot:
+            logger.debug("starting the bot")
+            await bot.start(config().token.get_secret_value())
 
 
 with suppress(KeyboardInterrupt):

--- a/app/components/accept_invite.py
+++ b/app/components/accept_invite.py
@@ -4,6 +4,7 @@ import discord as dc
 from discord.ext import commands
 from loguru import logger
 
+from app.config import config
 from toolbox.discord import is_dm, pretty_print_account, try_dm
 
 if TYPE_CHECKING:
@@ -22,7 +23,7 @@ class AcceptInvite(commands.Cog):
     async def accept_invite(self, interaction: dc.Interaction) -> None:
         assert not is_dm(interaction.user)
 
-        await try_dm(interaction.user, self.bot.config.accept_invite_url, silent=True)
+        await try_dm(interaction.user, config().accept_invite_url, silent=True)
         await try_dm(
             interaction.user,
             "Ghostty is already out! 👉 https://ghostty.org/",

--- a/app/components/close_help_post.py
+++ b/app/components/close_help_post.py
@@ -6,6 +6,7 @@ from discord import app_commands
 from discord.ext import commands
 
 import app.components.github_integration.entities.fmt as github_entities_fmt
+from app.config import config
 from toolbox.discord import generate_autocomplete, is_dm
 from toolbox.message_moving import MovedMessage
 
@@ -35,7 +36,7 @@ class Close(commands.GroupCog, group_name="close"):
         user = interaction.user
         if is_dm(user) or not (
             isinstance((post := interaction.channel), dc.Thread)
-            and post.parent_id == self.bot.config.help_channel_id
+            and post.parent_id == config().help_channel_id
         ):
             # Can only close posts in #help
             return False
@@ -172,12 +173,12 @@ class Close(commands.GroupCog, group_name="close"):
         post = interaction.channel
 
         assert isinstance(post, dc.Thread)
-        assert post.parent_id == self.bot.config.help_channel_id
+        assert post.parent_id == config().help_channel_id
 
         help_tags = {
             tag
             for tag in cast("dc.ForumChannel", post.parent).available_tags
-            if tag.id in self.bot.config.help_channel_tag_ids.values()
+            if tag.id in config().help_channel_tag_ids.values()
         }
 
         if set(post.applied_tags) & help_tags:
@@ -188,7 +189,7 @@ class Close(commands.GroupCog, group_name="close"):
 
         await interaction.response.defer(ephemeral=True)
 
-        desired_tag_id = self.bot.config.help_channel_tag_ids[tag]
+        desired_tag_id = config().help_channel_tag_ids[tag]
         await post.add_tags(next(tag for tag in help_tags if tag.id == desired_tag_id))
 
         if title_prefix is None:

--- a/app/components/docs.py
+++ b/app/components/docs.py
@@ -8,6 +8,7 @@ from discord.ext import commands
 from githubkit.exception import RequestFailed
 from loguru import logger
 
+from app.config import config, gh
 from toolbox.discord import generate_autocomplete
 from toolbox.message_moving import get_or_create_webhook
 
@@ -96,8 +97,8 @@ class Docs(commands.Cog):
 
     async def _get_file(self, path: str) -> str:
         return (
-            await self.bot.gh.rest.repos.async_get_content(
-                self.bot.config.github_org,
+            await gh().rest.repos.async_get_content(
+                config().github_org,
                 "website",
                 path,
                 headers={"Accept": "application/vnd.github.raw+json"},

--- a/app/components/github_integration/code_links.py
+++ b/app/components/github_integration/code_links.py
@@ -14,6 +14,7 @@ from githubkit.exception import RequestFailed
 from zig_codeblocks import highlight_zig_code
 
 from app.components.zig_codeblocks import FILE_HIGHLIGHT_NOTE, THEME
+from app.config import gh
 from toolbox.cache import TTRCache
 from toolbox.discord import suppress_embeds_after_delay
 from toolbox.linker import (
@@ -27,7 +28,6 @@ if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
     from app.bot import GhosttyBot
-    from toolbox.misc import GH
 
 CODE_LINK_PATTERN = re.compile(
     r"https?://(?:www\.)?github\.com/([a-zA-Z0-9\-]+)/([a-zA-Z0-9\-\._]+)/blob/"
@@ -59,14 +59,10 @@ class Snippet(NamedTuple):
 
 @final
 class ContentCache(TTRCache[SnippetPath, str]):
-    def __init__(self, gh: GH, **ttr: float) -> None:
-        super().__init__(**ttr)
-        self.gh: GH = gh
-
     @override
     async def fetch(self, key: SnippetPath) -> None:
         with suppress(RequestFailed):
-            resp = await self.gh.rest.repos.async_get_content(
+            resp = await gh().rest.repos.async_get_content(
                 key.owner,
                 key.repo,
                 key.path,
@@ -88,7 +84,7 @@ class CodeLinks(commands.Cog):
         self.bot = bot
         self.linker = MessageLinker()
         CodeLinkActions.linker = self.linker
-        self.cache = ContentCache(self.bot.gh, minutes=30)
+        self.cache = ContentCache(minutes=30)
 
     async def get_snippets(self, content: str) -> AsyncGenerator[Snippet]:
         for match in CODE_LINK_PATTERN.finditer(content):

--- a/app/components/github_integration/comments/discussions.py
+++ b/app/components/github_integration/comments/discussions.py
@@ -55,7 +55,7 @@ async def get_discussion_comment(
     packed = msgpack.packb([0, 0, comment_id])
     node_id = "DC_" + urlsafe_b64encode(packed).decode()
     try:
-        resp = await gh.graphql.arequest(
+        resp = await gh().graphql.arequest(
             DISCUSSION_COMMENT_QUERY, variables={"id": node_id}
         )
     except GraphQLFailed:

--- a/app/components/github_integration/comments/fetching.py
+++ b/app/components/github_integration/comments/fetching.py
@@ -327,7 +327,7 @@ async def _get_issue_comment(
 ) -> Comment | None:
     owner, repo, _ = entity_gist
     comment_resp, entity = await asyncio.gather(
-        gh.rest.issues.async_get_comment(owner, repo, comment_id),
+        gh().rest.issues.async_get_comment(owner, repo, comment_id),
         entity_cache.get(entity_gist),
     )
     comment = comment_resp.parsed_data
@@ -344,7 +344,7 @@ async def _get_issue_comment(
 
 async def _get_pr_review(entity_gist: EntityGist, comment_id: int) -> Comment | None:
     comment = (
-        await gh.rest.pulls.async_get_review(*entity_gist, comment_id)
+        await gh().rest.pulls.async_get_review(*entity_gist, comment_id)
     ).parsed_data
     entity = await entity_cache.get(entity_gist)
     return entity and Comment(
@@ -367,7 +367,7 @@ async def _get_pr_review_comment(
 ) -> Comment | None:
     owner, repo, _ = entity_gist
     comment = (
-        await gh.rest.pulls.async_get_review_comment(owner, repo, comment_id)
+        await gh().rest.pulls.async_get_review_comment(owner, repo, comment_id)
     ).parsed_data
     entity = await entity_cache.get(entity_gist)
     return entity and Comment(
@@ -417,7 +417,9 @@ def _make_crlf_codeblock(lang: str, body: str) -> str:
 
 async def _get_event(entity_gist: EntityGist, comment_id: int) -> Comment | None:
     owner, repo, entity_no = entity_gist
-    event = (await gh.rest.issues.async_get_event(owner, repo, comment_id)).parsed_data
+    event = (
+        await gh().rest.issues.async_get_event(owner, repo, comment_id)
+    ).parsed_data
     entity = await entity_cache.get(entity_gist)
     if not entity:
         return None
@@ -447,7 +449,7 @@ async def _get_event(entity_gist: EntityGist, comment_id: int) -> Comment | None
     elif event.event == "review_dismissed":
         dismissed_review = cast("IssueEventDismissedReview", event.dismissed_review)
         review = (
-            await gh.rest.pulls.async_get_review(
+            await gh().rest.pulls.async_get_review(
                 owner, repo, entity_no, dismissed_review.review_id
             )
         ).parsed_data

--- a/app/components/github_integration/commit_types.py
+++ b/app/components/github_integration/commit_types.py
@@ -9,8 +9,6 @@ from app.config import gh
 if TYPE_CHECKING:
     import datetime as dt
 
-    from toolbox.misc import GH
-
 
 class CommitKey(NamedTuple):
     owner: str
@@ -33,8 +31,7 @@ class CommitSummary(NamedTuple):
 
 @final
 class CommitCache:
-    def __init__(self, gh: GH) -> None:
-        self._gh: GH = gh
+    def __init__(self) -> None:
         self._cache: dict[CommitKey, CommitSummary] = {}
 
     def _filter_prefix(self, prefix: str) -> list[CommitKey]:
@@ -52,7 +49,7 @@ class CommitCache:
 
     async def _fetch(self, key: CommitKey) -> CommitSummary | None:
         try:
-            resp = await self._gh.rest.repos.async_get_commit(*key)
+            resp = await gh().rest.repos.async_get_commit(*key)
         except RequestFailed:
             return None
         obj = resp.parsed_data
@@ -74,4 +71,4 @@ class CommitCache:
         return commit_summary
 
 
-commit_cache = CommitCache(gh)
+commit_cache = CommitCache()

--- a/app/components/github_integration/entities/discussions.py
+++ b/app/components/github_integration/entities/discussions.py
@@ -34,7 +34,7 @@ query getDiscussion($number: Int!, $org: String!, $repo: String!) {
 
 async def get_discussion(org: str, name: str, number: int) -> Discussion | None:
     try:
-        resp = await gh.graphql.arequest(
+        resp = await gh().graphql.arequest(
             DISCUSSION_QUERY, variables={"number": number, "org": org, "repo": name}
         )
     except GraphQLFailed:

--- a/app/components/github_integration/entities/resolution.py
+++ b/app/components/github_integration/entities/resolution.py
@@ -44,7 +44,7 @@ def remove_codeblocks(content: str) -> str:
 
 
 async def find_repo_owner(name: str) -> str:
-    resp = await gh.rest.search.async_repos(
+    resp = await gh().rest.search.async_repos(
         q=name, sort="stars", order="desc", per_page=20
     )
     return next(
@@ -60,10 +60,10 @@ async def resolve_repo_signature(
     match owner, repo:
         case None, None:
             # The Ghostty repo
-            return config.github_org, "ghostty"
+            return config().github_org, "ghostty"
         case None, repo if repo in REPO_ALIASES:
             # Special ghostty-org prefixes
-            return config.github_org, REPO_ALIASES[repo]
+            return config().github_org, REPO_ALIASES[repo]
         case None, repo:
             # Only a name provided
             if repo_owner := await owner_cache.get(repo):

--- a/app/components/github_integration/webhooks/integration.py
+++ b/app/components/github_integration/webhooks/integration.py
@@ -43,9 +43,9 @@ class GitHubWebhooks(commands.Cog):
     def __init__(self, bot: GhosttyBot) -> None:
         self.bot = bot
         self.monalisten_client = Monalisten(
-            config.github_webhook_url.get_secret_value(),
-            token=config.github_webhook_secret.get_secret_value()
-            if config.github_webhook_secret
+            config().github_webhook_url.get_secret_value(),
+            token=token.get_secret_value()
+            if (token := config().github_webhook_secret)
             else None,
         )
         self._monalisten_task: asyncio.Task[None] | None = None

--- a/app/components/lock_old_posts.py
+++ b/app/components/lock_old_posts.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, final
 import discord as dc
 from discord.ext import commands
 
+from app.config import config
 from toolbox.discord import dynamic_timestamp, post_is_solved
 from toolbox.misc import aenumerate
 
@@ -27,7 +28,7 @@ class LockOldPosts(commands.Cog):
             message.author.bot
             or not isinstance(post, dc.Thread)
             or not post.parent
-            or post.parent.id != self.bot.config.help_channel_id
+            or post.parent.id != config().help_channel_id
             or post.locked
             or post.last_message_id is None
             or not post_is_solved(post)

--- a/app/components/message_filter.py
+++ b/app/components/message_filter.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, NamedTuple, cast, final
 import discord as dc
 from discord.ext import commands
 
+from app.config import config
 from toolbox.discord import format_or_file, try_dm
 from toolbox.messages import REGULAR_MESSAGE_TYPES
 from toolbox.misc import URL_REGEX
@@ -39,13 +40,13 @@ class MessageFilter(commands.Cog):
         self.message_filters = (
             # Delete non-image messages in #showcase
             MessageFilterTuple(
-                self.bot.config.showcase_channel_id,
+                config().showcase_channel_id,
                 lambda msg: cast("dc.Message", msg).attachments,
                 ("any attachments", "a screenshot or a video"),
             ),
             # Delete non-link messages in #media
             MessageFilterTuple(
-                self.bot.config.media_channel_id,
+                config().media_channel_id,
                 lambda msg: URL_REGEX.search(cast("dc.Message", msg).content),
                 ("a link", "a link"),
             ),

--- a/app/components/xkcd_mentions.py
+++ b/app/components/xkcd_mentions.py
@@ -133,7 +133,7 @@ class XKCDMentions(commands.Cog):
         channel = message.channel
         if isinstance(channel, dc.Thread) and channel.parent:
             channel = channel.parent
-        if channel.id in config.serious_channel_ids:
+        if channel.id in config().serious_channel_ids:
             return False
 
         # Filter out symbols to catch things like `foo*, bar`. Don't remove backticks to

--- a/app/log.py
+++ b/app/log.py
@@ -2,14 +2,13 @@ import inspect
 import logging
 import os
 import sys
-from typing import TYPE_CHECKING, override
+from typing import override
 
 import sentry_sdk
 from loguru import logger
 from sentry_sdk.integrations.asyncio import AsyncioIntegration
 
-if TYPE_CHECKING:
-    from app.config import Config
+from app.config import config
 
 
 # Both discord.py and httpx use the standard logging module; redirect them to Loguru.
@@ -40,7 +39,7 @@ class _InterceptHandler(logging.Handler):
         )
 
 
-def setup(config: Config) -> None:
+def setup() -> None:
     logging.basicConfig(handlers=[_InterceptHandler()], level=0, force=True)
 
     default_filter = {
@@ -59,10 +58,10 @@ def setup(config: Config) -> None:
         filters_str = " ".join(f"{f}={lvl}" for f, lvl in filters.items())
         logger.info("using log filters {}", filters_str)
 
-    if config.sentry_dsn is not None:
+    if (dsn := config().sentry_dsn) is not None:
         logger.info("initializing sentry")
         sentry_sdk.init(
-            dsn=config.sentry_dsn.get_secret_value(),
+            dsn=dsn.get_secret_value(),
             enable_logs=True,
             traces_sample_rate=1.0,
             profiles_sample_rate=1.0,

--- a/app/status.py
+++ b/app/status.py
@@ -106,13 +106,13 @@ class BotStatus:
 
     @staticmethod
     async def _get_github_data() -> SimpleNamespace:
-        match gh.auth:
+        match gh().auth:
             case TokenAuthStrategy(token) if token.startswith(("gh", "github")):
                 correct_token = True
             case _:
                 correct_token = False
         try:
-            resp = await gh.rest.users.async_get_authenticated()
+            resp = await gh().rest.users.async_get_authenticated()
             api_ok = resp.status_code == 200
         except RequestFailed:
             api_ok = False
@@ -133,7 +133,7 @@ class BotStatus:
             "launch_time": dynamic_timestamp(self.launch_time, "R"),
             "last_login_time": dynamic_timestamp(self.last_login_time, "R"),
             "last_sitemap_refresh": dynamic_timestamp(self.last_sitemap_refresh, "R"),
-            "help_channel": f"<#{config.help_channel_id}>",
+            "help_channel": f"<#{config().help_channel_id}>",
             "scan": self._get_scan_data(),
             "gh": await self._get_github_data(),
         }

--- a/packages/toolbox/src/toolbox/misc.py
+++ b/packages/toolbox/src/toolbox/misc.py
@@ -6,18 +6,13 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, AsyncIterable
 
-    from githubkit import GitHub, TokenAuthStrategy
-
 __all__ = (
-    "GH",
     "URL_REGEX",
     "aenumerate",
     "async_process_check_output",
     "format_diff_note",
     "truncate",
 )
-
-type GH = GitHub[TokenAuthStrategy]
 
 URL_REGEX = re.compile(
     r"https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b"

--- a/tests/test_close_help_post.py
+++ b/tests/test_close_help_post.py
@@ -5,6 +5,7 @@ from typing import Any, cast, get_args
 import pytest
 from githubkit.exception import RequestFailed
 
+from tests.utils import config
 from tests.utils import kitposer as kp
 
 from app.bot import EmojiName
@@ -69,29 +70,17 @@ emojis = cast(
     ("entity_id", "kind"),
     [(189, "Issue"), (1234, "Pull Request"), (2354, "Discussion")],
 )
-async def test_mention_entity(
-    entity_id: int,
-    kind: str,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    entities_subpkg_path = "app.components.github_integration.entities"
-    monkeypatch.setattr(f"{entities_subpkg_path}.cache.entity_cache.gh", gh_env)
-    monkeypatch.setattr(f"{entities_subpkg_path}.discussions.gh", gh_env)
-
-    msg_content = await Close.mention_entity(emojis, entity_id)
+async def test_mention_entity(entity_id: int, kind: str) -> None:
+    with config(), gh_env:
+        msg_content = await Close.mention_entity(emojis, entity_id)
 
     assert msg_content is not None
     assert f"{kind} [#{entity_id}]" in msg_content
 
 
 @pytest.mark.parametrize("entity_id", [-13, 1023, 8192])
-async def test_mention_missing_entity(
-    entity_id: int, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    entities_subpkg_path = "app.components.github_integration.entities"
-    monkeypatch.setattr(f"{entities_subpkg_path}.cache.entity_cache.gh", gh_env)
-    monkeypatch.setattr(f"{entities_subpkg_path}.discussions.gh", gh_env)
-
-    msg_content = await Close.mention_entity(emojis, entity_id)
+async def test_mention_missing_entity(entity_id: int) -> None:
+    with config(), gh_env:
+        msg_content = await Close.mention_entity(emojis, entity_id)
 
     assert msg_content is None

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,3 +1,4 @@
 from . import kitposer
+from .config import config
 
-__all__ = ("kitposer",)
+__all__ = ("config", "kitposer")

--- a/tests/utils/config.py
+++ b/tests/utils/config.py
@@ -1,0 +1,16 @@
+from typing import TYPE_CHECKING
+
+from app.config import Config, config_var
+
+if TYPE_CHECKING:
+    from contextvars import Token
+
+
+def config() -> Token[Config]:
+    """
+    Intended to be used as a context manager:
+
+        with config():
+            ...
+    """
+    return config_var.set(Config(".env.example"))


### PR DESCRIPTION
Re https://github.com/ghostty-org/discord-bot/pull/441#issuecomment-3869030576, xref #466.

The primary motive is to move their *construction* out of a global, so that tests can construct their own and, potentially in the future, relocation of GitHub integration code doesn't necessitate accessing mutable globals across packages, rather making the client a “package parameter” of sorts, and leaving creation of the client in the main package.

From #441:
> Is this useful? I originally did this because GhosttyBot was given a config and GitHub client but most users use globals instead, but this would help with isolating core GitHub functionality from the rest of the bot (as was considered recently on Discord) in the future. I decided to PR it before asking because it's hard to know without seeing what the code might look like.

This has a smaller scope than #441; notably, https://github.com/ghostty-org/discord-bot/pull/441/commits/1c504cccf7404bda65d4cb168707bdf8ca00cb13 is orthogonal to this PR, and I've PR'd half of it as #453.

The other half of that commit is explicitly threading `webhook_channels` through instead of grabbing it from `bot`, but I don't think context variables work for that, and threading them manually was arguably the ugliest part of #441. Furthermore, unlike emojis, I feel like the webhook channels are just as inherent to the bot as the other channel cached properties, and I don't want to consider threading those through parameters—the cached properties might deserve a better form of creation, such as putting the code in `Config`, making its `__init__` take `GhosttyBot` as a parameter, and constructing the configuration and client in `GhosttyBot` instead of `__main__`.

I'm also not sure if using a bot for those is better or worse than passing the webhook channels, since there's been next to no discussion on which parts of the GitHub integration code might be considered for moving to a separate package: what happens to the cogs, for example?

One thing that might be useful is making *`GhosttyBot` itself* a context variable. I'm not sure how weird that would be were GitHub integration to be moved to its own package in the future, though, so I didn't experiment with it. The primary allure of this is the number of random methods of `GhosttyBot` that feel like utility methods, but are tied to a Discord client and hence can't be in toolbox.

-----

One final related, but not directly relevant, issue present is the *construction* of caches. In https://github.com/ghostty-org/discord-bot/pull/441#issuecomment-3764133290, I stated caches have to be global to survive cog reloads, but I was mistaken—in reality, a bit over half the caches are created in the cog, while the others are globals. I think they should all either be global or created in the cog—**context variables work great here**—primarily as they exhibit different and *non-obvious* semantics around cog loading; there are arguments for both:

**When caches are global**:
  - Survives cog reloads—this may save requests after a cog reload. However, it is arguable whether this is desirable: cog reloads may help with treating heisenbug (which is often because of cache), or possibly, and this is purely theoretical, hot-reloading cogs (which may render old cache invalid, resulting in confusing bugs when used). However, cog reloads for other purposes result in unnecessary requests due to the cache being destroyed, and it may be feasible to create a command for clearing caches specifically, which provides more granularity over just reloading cogs (and such a command doesn't make sense if the caches aren't global).
  - Easiest to access.
  - Access from multiple cogs—the primary case global caches are currently used for—is straightforward: you just grab the global variable from whichever module it's present in and use it.

**When caches are created in cogs**:
  - Does not survive cog reloads: see above.
  - Less global state; context variables make it reasonably straightforward to access.
  - Access from multiple cogs becomes extremely complicated, with the simplest solution being giving every cog/component its own cache: the reversal of #451. Multiple caches means less cache hits, which is bad for obvious reasons. Workarounds like reference counting or something weird, similar to a previous design of #441, solve the locality issue but make cached data survive cog reloads: I can't think of how to avoid that while keeping a shared  cache across components (such as the entity cache, needed even outside `github_integration`, and the commit cache moved to a global in #451); tagging data with their creator cog leads to an issue when different cogs request the same data: is the data deleted? Are all requests stored, essentially giving each cached item a refcount? Tags are also fundamentally incompatible with `TTRCache`'s current design.
  - Were this done <ins>without context variables</ins>, moving the cache to a separate file (as done with the mention and comment caches) becomes non-trivial.

I would *like* for discussion on this to elicit before merging this PR, as the outcome **may influence the efficacy of introducing context variables** for state management, but this is primarily orthogonal to this PR and only related by the fact that context variables work great were caches not to be global, so it doesn't *need* to block merge.