### PR TITLE
Improve wording of PR review dismissal webhook title

### DIFF
--- a/app/components/github_integration/webhooks/prs.py
+++ b/app/components/github_integration/webhooks/prs.py
@@ -212,7 +212,7 @@ def register_hooks(bot: GhosttyBot, webhook: Monalisten) -> None:  # noqa: PLR09
             bot,
             event.sender,
             pr_embed_content(
-                pr, "dismissed a {} review", f"authored by {review_author.hyperlink}"
+                pr, "dismissed a review of {}", f"authored by {review_author.hyperlink}"
             ),
             pr_footer(pr, emoji=emoji),
             color="orange",


### PR DESCRIPTION
It currently looks like this:

<img width="579" height="190" alt="Screenshot of the old webhook title." src="https://github.com/user-attachments/assets/74a47c91-cc05-446f-a523-49afd4a7cc34" />

I personally think “PR #number” works better as a noun than an adverbial clause (since the latter is more complex to parse here), and this one is inconsistent with the other PR webhook titles which follow a “⟨verb⟩ a ⟨noun⟩ on PR #number” pattern.