### PR TITLE
Give webhook handler functions explicit names

### DIFF
--- a/app/components/github_integration/webhooks/commits.py
+++ b/app/components/github_integration/webhooks/commits.py
@@ -1,3 +1,5 @@
+# pyright: reportUnusedFunction=false
+
 from typing import TYPE_CHECKING
 
 from loguru import logger
@@ -15,9 +17,9 @@ if TYPE_CHECKING:
     from app.bot import GhosttyBot
 
 
-def register_hooks(bot: GhosttyBot, monalisten_client: Monalisten) -> None:
-    @monalisten_client.event.commit_comment
-    async def _(event: events.CommitComment) -> None:
+def register_hooks(bot: GhosttyBot, webhook: Monalisten) -> None:
+    @webhook.event.commit_comment
+    async def comment(event: events.CommitComment) -> None:
         full_sha = event.comment.commit_id
         sha = full_sha[:7]
 

--- a/app/components/github_integration/webhooks/discussions.py
+++ b/app/components/github_integration/webhooks/discussions.py
@@ -1,3 +1,5 @@
+# pyright: reportUnusedFunction=false
+
 from typing import TYPE_CHECKING, Literal, Protocol, cast
 
 from loguru import logger
@@ -71,7 +73,7 @@ def register_hooks(
     bot: GhosttyBot, webhook: Monalisten, vouch_queue: VouchQueue
 ) -> None:
     @webhook.event.discussion.created
-    async def _(event: events.DiscussionCreated) -> None:
+    async def created(event: events.DiscussionCreated) -> None:
         discussion = event.discussion
         await send_embed(
             bot,
@@ -84,7 +86,7 @@ def register_hooks(
         )
 
     @webhook.event.discussion.closed
-    async def _(event: events.DiscussionClosed) -> None:
+    async def closed(event: events.DiscussionClosed) -> None:
         discussion = event.discussion
         if not (
             discussion.state_reason
@@ -104,7 +106,7 @@ def register_hooks(
         )
 
     @webhook.event.discussion.reopened
-    async def _(event: events.DiscussionReopened) -> None:
+    async def reopened(event: events.DiscussionReopened) -> None:
         discussion = event.discussion
         await send_embed(
             bot,
@@ -116,7 +118,7 @@ def register_hooks(
         )
 
     @webhook.event.discussion.answered
-    async def _(event: events.DiscussionAnswered) -> None:
+    async def answered(event: events.DiscussionAnswered) -> None:
         discussion = event.discussion
         if answering_user := event.answer.user:
             gh_user = GitHubUser(**answering_user.model_dump())
@@ -134,7 +136,7 @@ def register_hooks(
         )
 
     @webhook.event.discussion.unanswered
-    async def _(event: events.DiscussionUnanswered) -> None:
+    async def unanswered(event: events.DiscussionUnanswered) -> None:
         discussion = event.discussion
         await send_embed(
             bot,
@@ -146,7 +148,7 @@ def register_hooks(
         )
 
     @webhook.event.discussion.locked
-    async def _(event: events.DiscussionLocked) -> None:
+    async def locked(event: events.DiscussionLocked) -> None:
         discussion = event.discussion
         await send_embed(
             bot,
@@ -158,7 +160,7 @@ def register_hooks(
         )
 
     @webhook.event.discussion.unlocked
-    async def _(event: events.DiscussionUnlocked) -> None:
+    async def unlocked(event: events.DiscussionUnlocked) -> None:
         discussion = event.discussion
         await send_embed(
             bot,
@@ -170,7 +172,7 @@ def register_hooks(
         )
 
     @webhook.event.discussion.pinned
-    async def _(event: events.DiscussionPinned) -> None:
+    async def pinned(event: events.DiscussionPinned) -> None:
         discussion = event.discussion
         await send_embed(
             bot,
@@ -182,7 +184,7 @@ def register_hooks(
         )
 
     @webhook.event.discussion.unpinned
-    async def _(event: events.DiscussionUnpinned) -> None:
+    async def unpinned(event: events.DiscussionUnpinned) -> None:
         discussion = event.discussion
         await send_embed(
             bot,
@@ -194,7 +196,7 @@ def register_hooks(
         )
 
     @webhook.event.discussion_comment.created
-    async def _(event: events.DiscussionCommentCreated) -> None:
+    async def comment_created(event: events.DiscussionCommentCreated) -> None:
         discussion = event.discussion
         footer = discussion_footer(discussion)
         if vouch_command := find_vouch_command(event.comment.body):

--- a/app/components/github_integration/webhooks/integration.py
+++ b/app/components/github_integration/webhooks/integration.py
@@ -1,3 +1,5 @@
+# pyright: reportUnusedFunction=false
+
 import asyncio
 from typing import TYPE_CHECKING, final, override
 
@@ -19,20 +21,20 @@ if TYPE_CHECKING:
 
 def register_internal_hooks(webhook: Monalisten) -> None:
     @webhook.internal.error
-    async def _(error: Error) -> None:
+    async def error(error: Error) -> None:
         error.exc.add_note(f"payload: {error.payload}")
         sentry_sdk.set_context("payload", error.payload or {})  # pyright: ignore[reportArgumentType]
         handle_error(error.exc)
 
     @webhook.internal.auth_issue
-    async def _(issue: AuthIssue) -> None:
+    async def auth_issue(issue: AuthIssue) -> None:
         guid = issue.payload.get("x-github-delivery", "<missing-guid>")
         logger.warning(
             "token {} in event {}: {}", issue.kind.value, guid, issue.payload
         )
 
     @webhook.internal.ready
-    async def _() -> None:
+    async def ready() -> None:
         logger.info("monalisten client ready")
 
 

--- a/app/components/github_integration/webhooks/issues.py
+++ b/app/components/github_integration/webhooks/issues.py
@@ -1,3 +1,5 @@
+# pyright: reportUnusedFunction=false
+
 import re
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
@@ -69,7 +71,7 @@ def register_hooks(
     bot: GhosttyBot, webhook: Monalisten, vouch_queue: VouchQueue
 ) -> None:
     @webhook.event.issues.opened
-    async def _(event: events.IssuesOpened) -> None:
+    async def opened(event: events.IssuesOpened) -> None:
         issue = event.issue
         body = remove_discussion_div(issue.body)
         await send_embed(
@@ -82,7 +84,7 @@ def register_hooks(
         )
 
     @webhook.event.issues.closed
-    async def _(event: events.IssuesClosed) -> None:
+    async def closed(event: events.IssuesClosed) -> None:
         issue = event.issue
         match issue.state_reason:
             case "completed":
@@ -103,7 +105,7 @@ def register_hooks(
         )
 
     @webhook.event.issues.reopened
-    async def _(event: events.IssuesReopened) -> None:
+    async def reopened(event: events.IssuesReopened) -> None:
         issue = event.issue
         await send_embed(
             bot,
@@ -114,11 +116,11 @@ def register_hooks(
         )
 
     @webhook.event.issues.edited
-    async def _(event: events.IssuesEdited) -> None:
+    async def edited(event: events.IssuesEdited) -> None:
         await send_edit_difference(bot, event, issue_embed_content, issue_footer)
 
     @webhook.event.issues.locked
-    async def _(event: events.IssuesLocked) -> None:
+    async def locked(event: events.IssuesLocked) -> None:
         issue = event.issue
         reason = f" as {r}" if (r := issue.active_lock_reason) else ""
         await send_embed(
@@ -130,7 +132,7 @@ def register_hooks(
         )
 
     @webhook.event.issues.unlocked
-    async def _(event: events.IssuesUnlocked) -> None:
+    async def unlocked(event: events.IssuesUnlocked) -> None:
         issue = event.issue
         await send_embed(
             bot,
@@ -141,7 +143,7 @@ def register_hooks(
         )
 
     @webhook.event.issues.pinned
-    async def _(event: events.IssuesPinned) -> None:
+    async def pinned(event: events.IssuesPinned) -> None:
         issue = event.issue
         await send_embed(
             bot,
@@ -152,7 +154,7 @@ def register_hooks(
         )
 
     @webhook.event.issues.unpinned
-    async def _(event: events.IssuesUnpinned) -> None:
+    async def unpinned(event: events.IssuesUnpinned) -> None:
         issue = event.issue
         await send_embed(
             bot,
@@ -163,7 +165,7 @@ def register_hooks(
         )
 
     @webhook.event.issue_comment.created
-    async def _(event: events.IssueCommentCreated) -> None:
+    async def comment_created(event: events.IssueCommentCreated) -> None:
         issue = event.issue
         title = "commented on "
         if issue.pull_request:

--- a/app/components/github_integration/webhooks/prs.py
+++ b/app/components/github_integration/webhooks/prs.py
@@ -1,3 +1,5 @@
+# pyright: reportUnusedFunction=false
+
 from itertools import dropwhile
 from typing import TYPE_CHECKING, Any, Literal, Protocol, cast
 
@@ -65,7 +67,7 @@ def register_hooks(  # noqa: C901, PLR0915
     bot: GhosttyBot, webhook: Monalisten, vouch_queue: VouchQueue
 ) -> None:
     @webhook.event.pull_request.opened
-    async def _(event: events.PullRequestOpened) -> None:
+    async def opened(event: events.PullRequestOpened) -> None:
         pr = event.pull_request
         if is_vouch_pr(event):
             logger.info(
@@ -85,7 +87,7 @@ def register_hooks(  # noqa: C901, PLR0915
         )
 
     @webhook.event.pull_request.closed
-    async def _(event: events.PullRequestClosed) -> None:
+    async def closed(event: events.PullRequestClosed) -> None:
         pr = event.pull_request
         action, color = ("merged", "purple") if pr.merged else ("closed", "red")
         if action == "merged" and is_vouch_pr(event):
@@ -119,7 +121,7 @@ def register_hooks(  # noqa: C901, PLR0915
         )
 
     @webhook.event.pull_request.reopened
-    async def _(event: events.PullRequestReopened) -> None:
+    async def reopened(event: events.PullRequestReopened) -> None:
         pr = event.pull_request
         await send_embed(
             bot,
@@ -130,11 +132,11 @@ def register_hooks(  # noqa: C901, PLR0915
         )
 
     @webhook.event.pull_request.edited
-    async def _(event: events.PullRequestEdited) -> None:
+    async def edited(event: events.PullRequestEdited) -> None:
         await send_edit_difference(bot, event, pr_embed_content, pr_footer)
 
     @webhook.event.pull_request.converted_to_draft
-    async def _(event: events.PullRequestConvertedToDraft) -> None:
+    async def converted_to_draft(event: events.PullRequestConvertedToDraft) -> None:
         pr = event.pull_request
         await send_embed(
             bot,
@@ -145,7 +147,7 @@ def register_hooks(  # noqa: C901, PLR0915
         )
 
     @webhook.event.pull_request.ready_for_review
-    async def _(event: events.PullRequestReadyForReview) -> None:
+    async def ready_for_review(event: events.PullRequestReadyForReview) -> None:
         pr = event.pull_request
         await send_embed(
             bot,
@@ -156,7 +158,7 @@ def register_hooks(  # noqa: C901, PLR0915
         )
 
     @webhook.event.pull_request.locked
-    async def _(event: events.PullRequestLocked) -> None:
+    async def locked(event: events.PullRequestLocked) -> None:
         pr = event.pull_request
         template = "locked {}"
         if reason := pr.active_lock_reason:
@@ -170,7 +172,7 @@ def register_hooks(  # noqa: C901, PLR0915
         )
 
     @webhook.event.pull_request.unlocked
-    async def _(event: events.PullRequestUnlocked) -> None:
+    async def unlocked(event: events.PullRequestUnlocked) -> None:
         pr = event.pull_request
         await send_embed(
             bot,
@@ -181,7 +183,7 @@ def register_hooks(  # noqa: C901, PLR0915
         )
 
     @webhook.event.pull_request.review_requested
-    async def _(event: events.PullRequestReviewRequested) -> None:
+    async def review_requested(event: events.PullRequestReviewRequested) -> None:
         pr = event.pull_request
         content = f"from {_format_reviewer(event)}"
         await send_embed(
@@ -192,7 +194,9 @@ def register_hooks(  # noqa: C901, PLR0915
         )
 
     @webhook.event.pull_request.review_request_removed
-    async def _(event: events.PullRequestReviewRequestRemoved) -> None:
+    async def review_request_removed(
+        event: events.PullRequestReviewRequestRemoved,
+    ) -> None:
         pr = event.pull_request
         content = f"from {_format_reviewer(event)}"
         await send_embed(
@@ -204,7 +208,7 @@ def register_hooks(  # noqa: C901, PLR0915
         )
 
     @webhook.event.pull_request_review.submitted
-    async def _(event: events.PullRequestReviewSubmitted) -> None:
+    async def submitted(event: events.PullRequestReviewSubmitted) -> None:
         pr, review = event.pull_request, event.review
 
         if review.state == "commented" and not review.body:
@@ -237,7 +241,7 @@ def register_hooks(  # noqa: C901, PLR0915
         )
 
     @webhook.event.pull_request_review.dismissed
-    async def _(event: events.PullRequestReviewDismissed) -> None:
+    async def dismissed(event: events.PullRequestReviewDismissed) -> None:
         pr = event.pull_request
         emoji = "pull_" + (
             "draft" if pr.draft else "merged" if pr.merged_at else pr.state
@@ -258,7 +262,7 @@ def register_hooks(  # noqa: C901, PLR0915
         )
 
     @webhook.event.pull_request_review_comment.created
-    async def _(event: events.PullRequestReviewCommentCreated) -> None:
+    async def created(event: events.PullRequestReviewCommentCreated) -> None:
         pr, content = event.pull_request, event.comment.body
 
         hunk = _reduce_diff_hunk(event.comment.diff_hunk)


### PR DESCRIPTION
Otherwise, they show up in the logs as `_`:
```
app.components.github_integration.webhooks.integration:_:36 - monalisten client ready
```