### PR TITLE
webhooks: add logging for events

### DIFF
--- a/app/components/github_integration/webhooks/commits.py
+++ b/app/components/github_integration/webhooks/commits.py
@@ -10,6 +10,7 @@ from app.components.github_integration.webhooks.utils import (
     Footer,
     send_embed,
 )
+from toolbox.misc import format_event_sender
 
 if TYPE_CHECKING:
     from monalisten import Monalisten, events
@@ -22,6 +23,11 @@ def register_hooks(bot: GhosttyBot, webhook: Monalisten) -> None:
     async def comment(event: events.CommitComment) -> None:
         full_sha = event.comment.commit_id
         sha = full_sha[:7]
+        logger.info(
+            "received a commit comment event for commit {!r} from {}",
+            sha,
+            format_event_sender(event.sender),
+        )
 
         owner, _, repo_name = event.repository.full_name.partition("/")
         if commit_summary := await commit_cache.get(

--- a/app/components/github_integration/webhooks/discussions.py
+++ b/app/components/github_integration/webhooks/discussions.py
@@ -14,6 +14,7 @@ from app.components.github_integration.webhooks.vouch import (
     find_vouch_command,
     register_vouch_command,
 )
+from toolbox.misc import format_event_sender
 
 if TYPE_CHECKING:
     from githubkit.versions.latest.models import DiscussionPropCategory, SimpleUser
@@ -72,6 +73,15 @@ def discussion_embed_content(
 def register_hooks(
     bot: GhosttyBot, webhook: Monalisten, vouch_queue: VouchQueue
 ) -> None:
+    @webhook.event.discussion
+    async def log_event(event: events.Discussion) -> None:
+        logger.info(
+            "received event {!r} for discussion #{} from {}",
+            event.action,
+            event.discussion.number,
+            format_event_sender(event.sender),
+        )
+
     @webhook.event.discussion.created
     async def created(event: events.DiscussionCreated) -> None:
         discussion = event.discussion

--- a/app/components/github_integration/webhooks/issues.py
+++ b/app/components/github_integration/webhooks/issues.py
@@ -15,6 +15,7 @@ from app.components.github_integration.webhooks.vouch import (
     find_vouch_command,
     register_vouch_command,
 )
+from toolbox.misc import format_event_sender
 
 if TYPE_CHECKING:
     from githubkit.typing import Missing
@@ -70,6 +71,15 @@ def issue_embed_content(
 def register_hooks(
     bot: GhosttyBot, webhook: Monalisten, vouch_queue: VouchQueue
 ) -> None:
+    @webhook.event.issues
+    async def log_event(event: events.Issues) -> None:
+        logger.info(
+            "received event {!r} for issue #{} from {}",
+            event.action,
+            event.issue.number,
+            format_event_sender(event.sender),
+        )
+
     @webhook.event.issues.opened
     async def opened(event: events.IssuesOpened) -> None:
         issue = event.issue

--- a/app/components/github_integration/webhooks/prs.py
+++ b/app/components/github_integration/webhooks/prs.py
@@ -18,6 +18,7 @@ from app.components.github_integration.webhooks.vouch import (
     extract_vouch_details,
     is_vouch_pr,
 )
+from toolbox.misc import format_event_sender
 
 if TYPE_CHECKING:
     from monalisten import Monalisten, events
@@ -66,6 +67,15 @@ def pr_embed_content(
 def register_hooks(  # noqa: C901, PLR0915
     bot: GhosttyBot, webhook: Monalisten, vouch_queue: VouchQueue
 ) -> None:
+    @webhook.event.pull_request
+    async def log_event(event: events.PullRequest) -> None:
+        logger.info(
+            "received event {!r} for PR #{} from {}",
+            event.action,
+            event.pull_request.number,
+            format_event_sender(event.sender),
+        )
+
     @webhook.event.pull_request.opened
     async def opened(event: events.PullRequestOpened) -> None:
         pr = event.pull_request

--- a/packages/toolbox/src/toolbox/misc.py
+++ b/packages/toolbox/src/toolbox/misc.py
@@ -6,6 +6,9 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, AsyncIterable
 
+    from githubkit.typing import Missing
+    from githubkit.versions.latest.models import SimpleUser
+
 __all__ = (
     "URL_REGEX",
     "aenumerate",
@@ -57,3 +60,7 @@ async def async_process_check_output(program: str, *args: str, **kwargs: Any) ->
             stderr=proc.stderr and await proc.stderr.read(),
         )
     return (await proc.stdout.read()).decode()
+
+
+def format_event_sender(sender: Missing[SimpleUser]) -> str:
+    return f"@{sender.login}" if sender else "?"


### PR DESCRIPTION
Closes #457. From the issue:
> Pretty sure having a catch-all `@webhook.events.any` handler would be enough.

The problem with that is that it forces Monalisten to parse *all* events it receives rather than just the ones we handle (and for example `workflow_run` events are often borked IIRC).