### PR TITLE
Don't log emoji failure to log channel

### DIFF
--- a/app/bot.py
+++ b/app/bot.py
@@ -199,8 +199,5 @@ class GhosttyBot(commands.Bot):
         }:
             emoji_list = ", ".join(missing_emojis)
             logger.error("failed to load emojis {}", emoji_list)
-            await config().log_channel.send(
-                f"Failed to load the following emojis: {emoji_list}"
-            )
 
         self.emojis_loaded.set()


### PR DESCRIPTION
There are better places if the logs don't need to be permanent—the previous line logs it to stderr (and maybe Sentry?) already.