### PR TITLE
Use Literal["❓"] instead of str

### DIFF
--- a/app/bot.py
+++ b/app/bot.py
@@ -42,7 +42,7 @@ EmojiName = Literal[
 
 _EMOJI_NAMES = frozenset(get_args(EmojiName))
 
-emojis_var = ContextVar[MappingProxyType[EmojiName, dc.Emoji | str]](
+emojis_var = ContextVar[MappingProxyType[EmojiName, dc.Emoji | Literal["❓"]]](
     "emojis", default=MappingProxyType(dict.fromkeys(_EMOJI_NAMES, "❓"))
 )
 emojis = emojis_var.get


### PR DESCRIPTION
xref https://github.com/ghostty-org/discord-bot/pull/468#pullrequestreview-3835638050, forgot you could do that until I saw basedpyright infer the question mark to have that type in an error.