### PR TITLE
Don't prefix discussion IDs with “discussion”

### DIFF
--- a/app/components/github_integration/webhooks/discussions.py
+++ b/app/components/github_integration/webhooks/discussions.py
@@ -63,8 +63,7 @@ def discussion_embed_content(
     discussion: DiscussionLike, template: str, body: str | None = None
 ) -> EmbedContent:
     return EmbedContent(
-        template.format(f"discussion #{discussion.number}")
-        + f" in {discussion.category.name}",
+        template.format(f"#{discussion.number}") + f" in {discussion.category.name}",
         discussion.html_url,
         body,
     )


### PR DESCRIPTION
Small change: currently discussions are sent as “opened discussion #1234 in Issue Triage”, but the only thing sent in `#discussion-feed` is, well, discussion events, which makes the qualifier redundant.

On the other hand, having “discussion” is consistent with issues PRs and commits, so feel free to close this if desired.