### PR TITLE
Use ruff format's `--diff` instead of `--check` in the justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -4,14 +4,14 @@ default:
 
 set windows-shell := ["cmd.exe", "/c"]
 
-# Run taplo, ruff, pytest, and basedpyright in check mode
+# Run ruff, basedpyright, pytest, taplo, and mdformat in check mode
 check:
     uv run ruff check
     @just check-package packages/toolbox
     uv run basedpyright app tests
     uv run pytest -p terminalprogress tests
     uv run taplo fmt --check --diff pyproject.toml config-example.toml
-    uv run ruff format --check
+    uv run ruff format --diff
     uv run mdformat --number --wrap 80 --check *.md
 
 [private]
@@ -20,13 +20,13 @@ check-package pkg:
     cd {{pkg}} && uv run pytest -p terminalprogress tests
     cd {{pkg}} && uv run taplo fmt --check --diff pyproject.toml config-example.toml
 
-# Run taplo, ruff's formatter, and ruff's isort rules in fix mode
+# Run taplo, ruff's formatter, ruff's isort rules, and mdformat in fix mode
 format:
     uv run taplo fmt pyproject.toml packages/*/pyproject.toml config-example.toml
     uv run ruff format
     uv run ruff check --select I,RUF022,RUF023 --fix
     uv run mdformat --number --wrap 80 *.md
 
-# Run taplo and ruff in fix mode
+# Run taplo, ruff, and mdformat in fix mode
 fix: format
     uv run ruff check --fix


### PR DESCRIPTION
\+ add mdformat to the doc comments, and reorder them to match the order of the checks.