### PR TITLE
Use `tool.ruff.lint.flake8-import-conventions.extend-aliases` instead of `aliases` to keep defaults

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ isort.known-local-folder = ["app", "toolbox"]
 [tool.ruff.format]
 preview = true
 
-[tool.ruff.lint.flake8-import-conventions.aliases]
+[tool.ruff.lint.flake8-import-conventions.extend-aliases]
 discord = "dc"
 datetime = "dt"
 


### PR DESCRIPTION
See https://docs.astral.sh/ruff/settings/#lint_flake8-import-conventions_aliases.