### PR TITLE
Do not format toolbox' nonexistent `config-example.toml`

### DIFF
--- a/justfile
+++ b/justfile
@@ -18,7 +18,7 @@ check:
 check-package pkg:
     cd {{pkg}} && uv run basedpyright src tests
     cd {{pkg}} && uv run pytest -p terminalprogress tests
-    cd {{pkg}} && uv run taplo fmt --check --diff pyproject.toml config-example.toml
+    cd {{pkg}} && uv run taplo fmt --check --diff pyproject.toml
 
 # Run taplo, ruff's formatter, ruff's isort rules, and mdformat in fix mode
 format:


### PR DESCRIPTION
It didn't cause issues because taplo silently ignores missing files.