### PR TITLE
Replace equality on `bool` with the bitwise XOR operator

### DIFF
--- a/app/components/fixup_embeds.py
+++ b/app/components/fixup_embeds.py
@@ -31,7 +31,7 @@ def _reddit_transformer(match: re.Match[str]) -> str | None:
 
     # Post links have either a subdomain (representing the subreddit) or a subreddit, so
     # ignore everything else.
-    if bool(match["subdomain"]) == bool(match["subreddit"]):
+    if not (bool(match["subdomain"]) ^ bool(match["subreddit"])):
         return None
 
     skin = f"{s}." if (s := match["skin"]) else ""

--- a/app/components/github_integration/commit_links.py
+++ b/app/components/github_integration/commit_links.py
@@ -116,7 +116,7 @@ class CommitLinks(commands.Cog):
                 continue
             if sep == "/blob/":
                 continue  # This is likely a code link
-            if bool(site) != (sep == "/commit/"):
+            if bool(site) ^ (sep == "/commit/"):
                 continue  # Separator was `@` despite this being a link or vice versa
             if site and not owner:
                 continue  # Not a valid GitHub link

--- a/app/components/github_integration/entities/resolution.py
+++ b/app/components/github_integration/entities/resolution.py
@@ -83,7 +83,7 @@ async def resolve_entity_signatures(
     for match in ENTITY_REGEX.finditer(remove_codeblocks(message.content)):
         site, sep = match["site"], match["sep"]
         # Ensure that the correct separator is used.
-        if bool(site) == (sep == "#"):
+        if not (bool(site) ^ (sep == "#")):
             continue
         # NOTE: this *must* be after the previous check, as the number can be an empty
         # string if an incorrect separator was used, which would result in a ValueError


### PR DESCRIPTION
At [one point], I had this one “manual” XNOR:

> ```py
> if (site and sep == "#") or (not site and sep != "#"):
> ```

I had then thought there was no Boolean XOR operator, since `^` (`__xor__`) is bitwise XOR (though it's usually overloaded as something unrelated to bits more often than used as a bitwise operator[^1]). But trag1c brought up that `==` suffices as XNOR, and suggested I instead do:

> ```py
> if bool(site) == (sep == "#"):
> ```

Which makes sense, but I had never realized that equality on Booleans is equivalent to XOR before (since I don't normally compare Booleans directly).

[one point]: https://github.com/ghostty-org/discord-bot/pull/196#discussion_r2029535832

A year and one month later (i.e.: an hour ago), I happened to be very sleepy and struggling through a bunch of De Morgans on some Boolean algebra + early return hell; I wasn't confident that `!=` was XOR (again, I was too sleepy to think it through properly) so wanted to verify it with a truth table just to make sure. I then happened to write this up:

```c
not(x) = !x
and(x, y) = x && y
nand(x, y) = !(x && y)
or(x, y) = x || y
nor(x, y) = !(x || y)
xnor(x, y) = x == y
xor(x, y) = x != y
```

Then exclaimed that it would be so nice if there was a proper Boolean XOR operator instead. It then struck me—since I set the syntax highlighting language for the above snippet to C—that were your Booleans to be represented as 0 or 1, à la C or [Python ≤ 2.3][bool-pep], bitwise XOR is identical to Boolean XOR; 🤦. And since Python's `bool` is a [subclass of `int` and coerces to 0 or 1][bool-pep], I figured the so-called “bitwise” XOR operator (`^`) would work just fine as a Boolean XOR on a `bool` too; and indeed it did.

So I decided to change `x != y` to `x ^ y` and `x == y` to `not (x ^ y)` since I think that conveys the intent better than comparing Booleans. Copilot [seemed to have agreed] too; not like that means anything, but I mention it as trag1c previously noted they were not convinced that using equality for XOR is confusing. Feel free to close this PR if you don't agree that `^` conveys the intent better than `!=`.

On a tangentially related note, seeing how minor this change is, here's some Frums to compensate: https://youtu.be/3qnrewFcnQs. Bonus points if you made the connection to the branch name before opening that link.

[bool-pep]: https://peps.python.org/pep-0285
[seemed to have agreed]: https://github.com/ghostty-org/discord-bot/pull/307#discussion_r2286096217

[^1]: I wonder how useful calling it bitwise XOR even is, seeing as it's Boolean XOR on `bool` and symmetric difference on `set` too—is there even any type other than `int` where it has anything to do with bits?