### PR TITLE
Merge review request webhook events into one

### DIFF
--- a/app/components/github_integration/models.py
+++ b/app/components/github_integration/models.py
@@ -49,6 +49,13 @@ class GitUser(NamedTuple):
         return f"`{self.name}`"
 
 
+class GitHubTeam(NamedTuple):
+    name: str
+
+    def format(self) -> str:
+        return f"the `{self.name}` team"
+
+
 class Reactions(BaseModel, frozen=True):
     plus_one: int
     minus_one: int

--- a/app/components/github_integration/models.py
+++ b/app/components/github_integration/models.py
@@ -2,14 +2,7 @@
 import datetime as dt
 from typing import TYPE_CHECKING, Annotated, Literal, NamedTuple, Self, cast, override
 
-from pydantic import (
-    AliasChoices,
-    BaseModel,
-    BeforeValidator,
-    ConfigDict,
-    Field,
-    field_validator,
-)
+from pydantic import AliasChoices, BaseModel, BeforeValidator, Field, field_validator
 
 from toolbox.misc import truncate
 
@@ -30,9 +23,7 @@ def state_validator(value: object) -> bool:
             raise ValueError(msg)
 
 
-class GitHubUser(BaseModel):
-    model_config = ConfigDict(frozen=True)
-
+class GitHubUser(BaseModel, frozen=True):
     name: str = Field(alias="login")
     # `html_url` comes before `url` to prefer the human-readable GitHub page link when
     # both fields are present
@@ -58,9 +49,7 @@ class GitUser(NamedTuple):
         return f"`{self.name}`"
 
 
-class Reactions(BaseModel):
-    model_config = ConfigDict(frozen=True)
-
+class Reactions(BaseModel, frozen=True):
     plus_one: int
     minus_one: int
     laugh: int
@@ -71,9 +60,7 @@ class Reactions(BaseModel):
     rocket: int
 
 
-class Entity(BaseModel):
-    model_config = ConfigDict(frozen=True)
-
+class Entity(BaseModel, frozen=True):
     number: int
     title: str
     body: str | None
@@ -104,7 +91,7 @@ class Entity(BaseModel):
         return True
 
 
-class Issue(Entity):
+class Issue(Entity, frozen=True):
     closed: Annotated[bool, Field(alias="state"), BeforeValidator(state_validator)]
     state_reason: Literal["completed", "reopened", "not_planned", "duplicate"] | None
     labels: tuple[str, ...]  # a tuple so that the model is hashable
@@ -115,7 +102,7 @@ class Issue(Entity):
         return tuple(cast("str", label.name) for label in value)
 
 
-class PullRequest(Entity):
+class PullRequest(Entity, frozen=True):
     closed: Annotated[bool, Field(alias="state"), BeforeValidator(state_validator)]
     draft: bool
     merged: bool
@@ -124,7 +111,7 @@ class PullRequest(Entity):
     changed_files: int
 
 
-class Discussion(Entity):
+class Discussion(Entity, frozen=True):
     answered_by: GitHubUser | None
     closed: bool
     state_reason: Literal["DUPLICATE", "RESOLVED", "OUTDATED", "REOPENED"] | None
@@ -145,9 +132,7 @@ class EntityGist(NamedTuple):
         return f"{self.owner}/{self.repo}#{self.number}"
 
 
-class Comment(BaseModel):
-    model_config = ConfigDict(frozen=True)
-
+class Comment(BaseModel, frozen=True):
     author: GitHubUser
     body: str
     reactions: Reactions | None = None

--- a/app/components/github_integration/webhooks/integration.py
+++ b/app/components/github_integration/webhooks/integration.py
@@ -59,7 +59,7 @@ class GitHubWebhooks(commands.Cog):
         register_internal_hooks(self.monalisten_client)
         discussions.register_hooks(self.monalisten_client, self._vouch_queue)
         issues.register_hooks(self.monalisten_client, self._vouch_queue)
-        prs.register_hooks(self.monalisten_client, self._vouch_queue)
+        prs.register_hooks(self.monalisten_client, self._vouch_queue, {})
         commits.register_hooks(self.monalisten_client)
 
         # Maintain strong reference to avoid task from being gc

--- a/app/components/github_integration/webhooks/prs.py
+++ b/app/components/github_integration/webhooks/prs.py
@@ -6,6 +6,9 @@ from typing import TYPE_CHECKING, Any, Literal, Protocol, cast
 from loguru import logger
 
 from app.components.github_integration.models import GitHubUser
+from app.components.github_integration.webhooks.review_summary import (
+    handle_review_request,
+)
 from app.components.github_integration.webhooks.utils import (
     EmbedContent,
     Footer,
@@ -25,6 +28,10 @@ if TYPE_CHECKING:
     from monalisten import Monalisten, events
 
     from app.bot import EmojiName
+    from app.components.github_integration.webhooks.review_summary import (
+        ReviewPools,
+        ReviewRequestsModified,
+    )
     from app.components.github_integration.webhooks.vouch import VouchQueue
 
 # This looks like a silly const but I wanted to have a single place to document this:
@@ -69,7 +76,11 @@ def pr_embed_content(
     )
 
 
-def register_hooks(webhook: Monalisten, vouch_queue: VouchQueue) -> None:  # noqa: C901, PLR0915
+def register_hooks(  # noqa: C901, PLR0915
+    webhook: Monalisten,
+    vouch_queue: VouchQueue,
+    review_pools: ReviewPools,
+) -> None:
     @webhook.event.pull_request
     async def log_event(event: events.PullRequest) -> None:
         logger.info(
@@ -216,28 +227,17 @@ def register_hooks(webhook: Monalisten, vouch_queue: VouchQueue) -> None:  # noq
             color="blue",
         )
 
-    @webhook.event.pull_request.review_requested
-    async def review_requested(event: events.PullRequestReviewRequested) -> None:
-        pr = event.pull_request
-        content = f"from {_format_reviewer(event)}"
-        await send_embed(
-            event.sender,
-            pr_embed_content(pr, "requested review for {}", content),
-            pr_footer(pr),
-        )
-
+    @webhook.event.pull_request.review_requested  # pyright: ignore[reportArgumentType]
     @webhook.event.pull_request.review_request_removed
-    async def review_request_removed(
-        event: events.PullRequestReviewRequestRemoved,
-    ) -> None:
+    async def review_requests_modified(event: ReviewRequestsModified) -> None:
         pr = event.pull_request
-        content = f"from {_format_reviewer(event)}"
-        await send_embed(
-            event.sender,
-            pr_embed_content(pr, "removed review request for {}", content),
-            pr_footer(pr),
-            origin_repo=event.repository,
-        )
+        if summary := await handle_review_request(review_pools, event):
+            title, body = summary.format()
+            await send_embed(
+                event.sender,
+                pr_embed_content(pr, f"{title} for {{}}", description=body),
+                pr_footer(pr),
+            )
 
     @webhook.event.pull_request_review.submitted
     async def submitted(event: events.PullRequestReviewSubmitted) -> None:
@@ -330,12 +330,3 @@ def _reduce_diff_hunk(hunk: str) -> str:
 
     hunk_lines = [*dropwhile(missing_diff_marker, hunk.splitlines())]
     return "\n".join([*dropwhile(missing_diff_marker, hunk_lines[::-1])][::-1])
-
-
-# Abusing `Any`/`getattr`/`hasattr` here because the API models are insufferable
-def _format_reviewer(event: Any) -> str:
-    if hasattr(event, "requested_team"):
-        return f"the `{event.requested_team.name}` team"
-    if requested_reviewer := getattr(event, "requested_reviewer", None):
-        return GitHubUser(**requested_reviewer.model_dump()).format()
-    return "`?`"

--- a/app/components/github_integration/webhooks/review_summary.py
+++ b/app/components/github_integration/webhooks/review_summary.py
@@ -1,0 +1,272 @@
+import asyncio
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, NamedTuple, Self
+
+from loguru import logger
+from monalisten import events
+
+from app.components.github_integration.models import GitHubTeam, GitHubUser
+from toolbox.misc import drain_queue
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterable
+
+
+REVIEW_REQUEST_GROUP_TIMEOUT = 5  # seconds
+
+
+type Reviewer = GitHubUser | GitHubTeam
+type ReviewRequestsModified = (
+    events.PullRequestReviewRequested | events.PullRequestReviewRequestRemoved
+)
+type ReviewPools = dict[ReviewPoolKey, asyncio.Queue[ReviewRequestsModified]]
+
+
+class ReviewPoolKey(NamedTuple):
+    """
+    The minimum amount of data needed to differentiate semantic groups of review
+    requests or removals.
+    """
+
+    pr_number: int
+    actor_id: int
+
+
+async def handle_review_request(
+    review_pools: ReviewPools,
+    event: ReviewRequestsModified,
+    *,
+    timeout: int | None = REVIEW_REQUEST_GROUP_TIMEOUT,  # noqa: ASYNC109
+) -> ReviewRequestSummary | None:
+    key = ReviewPoolKey(pr_number=event.pull_request.number, actor_id=event.sender.id)
+
+    # If we already have a queue for this PR+user combination, simply collect to it.
+    if q := review_pools.get(key):
+        logger.info("found existing review pool for key {key}", key=key)
+        await q.put(event)
+        return None
+
+    logger.info(
+        "creating new review pool #{n} for key {key}", n=len(review_pools) + 1, key=key
+    )
+    q = asyncio.Queue[ReviewRequestsModified]()
+    review_pools[key] = q
+    # This won't throw QueueShutDown as it cannot be shut down yet: the timeout
+    # hasn't been set.
+    await q.put(event)
+    # The coroutine calling this function will see this queue through to the end;
+    # future review_request() calls for this queue will terminate immediately after
+    # updating the queue.
+
+    async def timer() -> None:
+        if timeout is None:
+            return
+        await asyncio.sleep(timeout)
+        del review_pools[key]
+        # Signal the timeout to the queue.
+        q.shutdown()
+        logger.info(
+            "shut down review pool {key} ({n} remain)", key=key, n=len(review_pools)
+        )
+
+    async with asyncio.TaskGroup() as group:  # transparently handle cancelation.
+        group.create_task(timer())
+        summary = group.create_task(ReviewRequestSummary.collect(drain_queue(q)))
+
+    return summary.result()
+
+
+def _parse_reviewer(event: ReviewRequestsModified) -> Reviewer | None:
+    # Abusing duck typing here because the API models are insufferable.
+    event_dyn: Any = event
+    if hasattr(event_dyn, "requested_team"):
+        return GitHubTeam(name=event_dyn.requested_team.name)
+    if requested_reviewer := getattr(event_dyn, "requested_reviewer", None):
+        return GitHubUser(**requested_reviewer.model_dump())
+    return None
+
+
+@dataclass(kw_only=True)
+class ReviewRequestSummary:
+    requests: set[Reviewer] = field(default_factory=set)
+    removals: set[Reviewer] = field(default_factory=set)
+    # When a review was requested from somebody, then later removed.
+    accidental_requests: set[Reviewer] = field(default_factory=set)
+    # When a review request for somebody was removed, then later re-requested.
+    rerequests: set[Reviewer] = field(default_factory=set)
+    unknown_requests: int = 0  # count.
+    unknown_removals: int = 0  # count.
+
+    def __bool__(self) -> bool:
+        return bool(
+            self.requests
+            or self.removals
+            or self.accidental_requests
+            or self.rerequests
+            or self.unknown_requests
+            or self.unknown_removals
+        )
+
+    @staticmethod
+    def _categorize(
+        r: Reviewer,
+        *,
+        default_set: set[Reviewer],
+        opposite_set: set[Reviewer],
+        null_set: set[Reviewer],
+        opposite_null_set: set[Reviewer],
+    ) -> None:
+        """
+        Categorize a reviewer given its event and the opposite event's sets. This
+        function mutates the passed sets.
+
+        Arguments:
+            default_set -- The set associated with this event (`removals`/`requests`).
+            opposite_set -- The set associated with the opposite event (`removals` for
+                requests; `requests` for removals).
+            null_set -- The set associated with events of this type that were later
+                undone; i.e.: requesting a review then removing it again (represented by
+                `accidental_requests`), or removing a request then requesting it again
+                (represented by `rerequests`).
+            opposite_null_set -- Likewise, but for the opposite event.
+
+        Note that the null sets are sets of reviewers with a null (zero *delta*, and
+        aren't always-null (empty) sets.
+        """
+        # NOTE: an invariant is that every reviewer is only present in one set at
+        # a time, which is asserted in every branch below as a precaution.
+        if r in null_set:
+            # Either:
+            #   - a review was requested (r put in `requests`), then removed (r put in
+            #     `accidental_requests`), then requested again (this event).
+            #   - a review request was removed (r put in `removals`), then requested (r
+            #     put in `rerequests`), then removed again (this event).
+            # These request/remove cycles can be arbitrarily long, so we'll only show
+            # the difference between the initial and final states—that is, we'll undo
+            # the previous update which moved it from the default set to the null set.
+            for s in (default_set, opposite_set, opposite_null_set):
+                assert r not in s
+            default_set.add(r)
+            null_set.discard(r)
+        elif r in opposite_null_set:
+            # Either:
+            #   - a review request was removed (r put in `removals`), then requested (r
+            #     put in `rerequests`), then requested again (this event).
+            #   - a review was requested (r put in `requests`), then removed (r put in
+            #     `accidental_requests`), then removed again (this event).
+            # This is impossible in theory but random chance writes better applications
+            # than GitHub, so just ignore it.
+            for s in (default_set, opposite_set):
+                assert r not in s
+            logger.warning(
+                "ignoring theoretically impossible duplicate review undo event for {r}",
+                r=r.name,
+            )
+        elif r in opposite_set:
+            # Either a review request was removed then requested again, or the opposite.
+            # This event is the second one, so we want to move it to the *opposite* null
+            # set—that of the *first*.
+            assert r not in default_set
+            opposite_null_set.add(r)
+            opposite_set.discard(r)
+        elif r in default_set:
+            # A review was requested twice in a row, or a review request was likewise
+            # removed. Again, this is impossible in theory, but GitHub's webhook event
+            # synchronization is, to say the least, nonexistent.
+            logger.warning(
+                "ignoring theoretically impossible duplicate review event for {r}",
+                r=r.name,
+            )
+        else:
+            default_set.add(r)
+
+    @classmethod
+    async def collect(cls, it: AsyncIterable[ReviewRequestsModified]) -> Self:
+        summary = cls()
+        async for ev in it:
+            r = _parse_reviewer(ev)
+            if isinstance(ev, events.PullRequestReviewRequested):
+                if r is None:
+                    summary.unknown_requests += 1
+                else:
+                    summary._categorize(
+                        r,
+                        default_set=summary.requests,
+                        opposite_set=summary.removals,
+                        null_set=summary.accidental_requests,
+                        opposite_null_set=summary.rerequests,
+                    )
+            else:  # noqa: PLR5501 # the symmetry improves clarity.
+                if r is None:
+                    summary.unknown_removals += 1
+                else:
+                    summary._categorize(
+                        r,
+                        default_set=summary.removals,
+                        opposite_set=summary.requests,
+                        null_set=summary.rerequests,
+                        opposite_null_set=summary.accidental_requests,
+                    )
+        return summary
+
+    @staticmethod
+    def _format_reviewers(
+        reviewers: set[Reviewer], unknown: int = 0, *, heading: str | None = None
+    ) -> str:
+        heading_ = f"**{heading}** " * (heading is not None)
+        match sorted(reviewers, key=lambda r: r.name):
+            case [] if unknown:
+                # Only unknowns.
+                return f"{heading_}from {unknown} unknown users"
+            case []:
+                return ""
+            # Unknowns go on a separate line, so if there is both a reviewer and
+            # unknowns, go down the last case instead so that they're formatted on
+            # multiple lines.
+            case [reviewer] if not unknown:
+                return f"{heading_}from {reviewer.format()}"
+            case rs:
+                return (
+                    f"{heading_}from:\n"
+                    + "\n".join(f"- {r.format()}" for r in rs)
+                    + (f"\n- {unknown} unknown users" if unknown else "")
+                )
+
+    def format(self) -> tuple[str, str]:
+        """Return the appropriate title and body, respectively, in a 2-tuple."""
+        have_requests = bool(self.requests or self.unknown_requests)
+        have_removals = bool(self.removals or self.unknown_removals)
+        if (
+            self.accidental_requests
+            or self.rerequests
+            or not (have_requests ^ have_removals)
+        ):
+            sections = (
+                self._format_reviewers(
+                    self.requests, self.unknown_requests, heading="Requested review"
+                ),
+                self._format_reviewers(
+                    self.removals,
+                    self.unknown_removals,
+                    heading="Removed review request",
+                ),
+                self._format_reviewers(
+                    self.accidental_requests, heading="Accidentally requested review"
+                ),
+                self._format_reviewers(
+                    self.rerequests, heading="Removed, then requested review"
+                ),
+            )
+            return "updated review requests", "\n\n".join(filter(None, sections))
+        if have_requests:
+            return "requested review", self._format_reviewers(
+                self.requests, self.unknown_requests
+            )
+        if have_removals:
+            return "removed review request", self._format_reviewers(
+                self.removals, self.unknown_removals
+            )
+        # Fail loudly in case someone messes up when updating the Boolean algebra hell
+        # above.
+        msg = "unreachable"
+        raise AssertionError(msg)

--- a/packages/toolbox/src/toolbox/misc.py
+++ b/packages/toolbox/src/toolbox/misc.py
@@ -1,16 +1,19 @@
 import asyncio
 import re
 import subprocess
+from contextlib import suppress
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, AsyncIterable
+    from collections.abc import AsyncGenerator, AsyncIterable, Sequence
 
 __all__ = (
     "COLOR_PALETTE",
     "URL_REGEX",
     "aenumerate",
     "async_process_check_output",
+    "drain_queue",
+    "seq_to_aiter",
     "truncate",
 )
 
@@ -29,6 +32,17 @@ URL_REGEX = re.compile(
     r"https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b"
     r"(?:[-a-zA-Z0-9()@:%_\+.~#?&//=]*)"
 )
+
+
+async def seq_to_aiter[T](elems: Sequence[T]) -> AsyncGenerator[T]:
+    """
+    Convert any sequence to an asynchronous iterator. Synchronous iterables in general
+    aren't supported as this function doesn't magically insert await points into
+    them—computing the elements would block the scheduler until it finishes if it takes
+    a nontrivial amount of time!
+    """
+    for elem in elems:
+        yield elem
 
 
 def truncate(s: str, length: int, *, suffix: str = "…") -> str:
@@ -62,3 +76,10 @@ async def async_process_check_output(program: str, *args: str, **kwargs: Any) ->
             stderr=proc.stderr and await proc.stderr.read(),
         )
     return (await proc.stdout.read()).decode()
+
+
+async def drain_queue[T](queue: asyncio.Queue[T]) -> AsyncGenerator[T]:
+    """Yield `queue.get()` repeatedly until it has been shut down."""
+    with suppress(asyncio.QueueShutDown):
+        while True:
+            yield await queue.get()

--- a/packages/toolbox/tests/test_misc_utils.py
+++ b/packages/toolbox/tests/test_misc_utils.py
@@ -1,26 +1,31 @@
+import asyncio
 import subprocess
 import sys
-from typing import TYPE_CHECKING
 
 import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
-from toolbox.misc import aenumerate, async_process_check_output, truncate
+from tests.utils import any_comparables
 
-if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator
+from toolbox.misc import (
+    aenumerate,
+    async_process_check_output,
+    drain_queue,
+    seq_to_aiter,
+    truncate,
+)
 
 
-@given(st.lists(st.from_type(type)), st.integers())
-async def test_aenumerate[T](items: list[T], start: int) -> None:
-    async def async_iterator() -> AsyncGenerator[T]:
-        for item in items:
-            yield item
+@given(st.lists(any_comparables()))
+async def test_seq_to_aiter(elems: list[object]) -> None:
+    assert [e async for e in seq_to_aiter(elems)] == elems
 
-    assert [x async for x in aenumerate(async_iterator(), start)] == list(
-        enumerate(items, start)
-    )
+
+@given(st.lists(any_comparables()), st.integers())
+async def test_aenumerate(elems: list[object], start: int) -> None:
+    result = [e async for e in aenumerate(seq_to_aiter(elems), start)]
+    assert result == list(enumerate(elems, start))
 
 
 @pytest.mark.parametrize(
@@ -63,3 +68,24 @@ async def test_async_process_check_output_fails() -> None:
 async def test_async_process_check_output_invalid_argument() -> None:
     with pytest.raises(ValueError, match="stdout argument not allowed"):
         await async_process_check_output("", stdout=subprocess.DEVNULL)
+
+
+@given(st.lists(any_comparables()))
+async def test_drain_queue(elems: list[object]) -> None:
+    queue = asyncio.Queue[object]()
+
+    async def producer() -> None:
+        for e in elems:
+            await queue.put(e)
+        queue.shutdown()
+
+    async def consumer() -> None:
+        async for i, e in aenumerate(drain_queue(queue)):
+            assert e == elems[i]
+
+    async with asyncio.TaskGroup() as group:
+        group.create_task(producer())
+        group.create_task(consumer())
+
+    with pytest.raises(asyncio.QueueShutDown):
+        await queue.get()

--- a/packages/toolbox/tests/utils.py
+++ b/packages/toolbox/tests/utils.py
@@ -1,0 +1,18 @@
+from contextlib import suppress
+
+from hypothesis import strategies as st
+
+
+def any_comparables() -> st.SearchStrategy[object]:
+    """Generate anything Hypothesis can generate that equals itself."""
+
+    def is_comparable(x: object) -> bool:
+        # Suppress all exceptions because some values (such as signaling NaNs:
+        # Decimal("sNaN")) throw an exception when compared.
+        with suppress(Exception):
+            # Disable the self-comparison lint as Hypothesis might be able to generate
+            # values other than NaN that don't compare equal to themself.
+            return x == x  # noqa: PLR0124
+        return False
+
+    return st.from_type(object).filter(is_comparable)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,10 @@ runtime-evaluated-base-classes = [
   "pydantic.BaseModel",
   "pydantic_settings.BaseSettings",
 ]
+runtime-evaluated-decorators = [
+  "hypothesis.given",
+  "hypothesis.strategies.composite",
+]
 
 [tool.ruff.lint.per-file-ignores]
 "**/tests/*" = ["FBT", "SLF001", "PLR0913"]

--- a/tests/webhooks/test_prs.py
+++ b/tests/webhooks/test_prs.py
@@ -1,18 +1,12 @@
 # pyright: reportPrivateUsage=false
 
 from typing import TYPE_CHECKING
-from unittest.mock import Mock
 
 import pytest
-from githubkit.versions.latest.models import SimpleUser
 
 from tests.webhooks.utils import make_pr
 
-from app.components.github_integration.webhooks.prs import (
-    _format_reviewer,
-    _reduce_diff_hunk,
-    pr_footer,
-)
+from app.components.github_integration.webhooks.prs import _reduce_diff_hunk, pr_footer
 
 if TYPE_CHECKING:
     from app.bot import EmojiName
@@ -52,31 +46,3 @@ def test_pr_footer(state: str, draft: bool, merged: bool, expected: EmojiName) -
 )
 def test_reduce_diff_hunk(hunk: str, expected: str) -> None:
     assert _reduce_diff_hunk(hunk) == expected
-
-
-def test_format_reviewer_team() -> None:
-    team = Mock(())
-    team.name = "core-team"
-    event = Mock((), requested_team=team)
-    assert _format_reviewer(event) == "the `core-team` team"
-
-
-def test_format_reviewer_user() -> None:
-    user = Mock(
-        SimpleUser,
-        model_dump=Mock(
-            (),
-            return_value={
-                "login": "reviewer",
-                "html_url": "https://github.com/reviewer",
-                "avatar_url": "https://avatars.githubusercontent.com/u/1",
-            },
-        ),
-    )
-    event = Mock((), requested_reviewer=user)
-    result = _format_reviewer(event)
-    assert "reviewer" in result
-
-
-def test_format_reviewer_none() -> None:
-    assert _format_reviewer(Mock(())) == "`?`"

--- a/tests/webhooks/test_review_summary.py
+++ b/tests/webhooks/test_review_summary.py
@@ -1,0 +1,701 @@
+# pyright: reportPrivateUsage=false
+
+import asyncio
+from unittest.mock import Mock
+
+import pytest
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+from monalisten.events import PullRequestReviewRequested as PRReviewReq
+from monalisten.events import PullRequestReviewRequestRemoved as PRReviewReqRm
+
+from tests.webhooks.utils import (
+    DEFAULT_PR_SENDER_ID,
+    add_pr_metadata,
+    dummy_user,
+    github_teams,
+    github_users,
+    review_request_modification_events,
+    review_request_summaries,
+    reviewers,
+    team_review_request,
+    unknown_review_request,
+    user_review_request,
+)
+
+from app.components.github_integration.models import GitHubTeam, GitHubUser
+from app.components.github_integration.webhooks.review_summary import (
+    Reviewer,
+    ReviewPoolKey,
+    ReviewPools,
+    ReviewRequestsModified,
+    ReviewRequestSummary,
+    _parse_reviewer,
+    handle_review_request,
+)
+from toolbox.misc import seq_to_aiter
+
+
+def test_empty_review_request_summary_falsy() -> None:
+    assert not ReviewRequestSummary()
+
+
+@given(github_users())
+def test_parse_reviewer_user(user: GitHubUser) -> None:
+    event = user_review_request(
+        name=user.name, html_url=user.url, avatar_url=user.icon_url
+    )
+    assert _parse_reviewer(event) == user
+
+
+@given(github_teams())
+def test_parse_reviewer_team(team: GitHubTeam) -> None:
+    assert _parse_reviewer(team_review_request(name=team.name)) == team
+
+
+def test_parse_reviewer_none() -> None:
+    assert _parse_reviewer(Mock(())) is None
+
+
+@settings(max_examples=25)
+@given(st.lists(review_request_modification_events(include_unknowns=False)))
+async def test_collect_review_request_summary_contains_all_reviewers(
+    requests: list[ReviewRequestsModified],
+) -> None:
+    reviewers = set(map(_parse_reviewer, requests))
+    s = await ReviewRequestSummary.collect(seq_to_aiter(requests))
+    assert s.requests | s.removals | s.accidental_requests | s.rerequests == reviewers
+
+
+@settings(max_examples=25)
+@given(st.lists(review_request_modification_events()))
+async def test_collect_review_request_summary_has_no_duplicate_reviewers(
+    requests: list[ReviewRequestsModified],
+) -> None:
+    s = await ReviewRequestSummary.collect(seq_to_aiter(requests))
+    assert len(s.requests | s.removals | s.accidental_requests | s.rerequests) == (
+        len(s.requests)
+        + len(s.removals)
+        + len(s.accidental_requests)
+        + len(s.rerequests)
+    )
+
+
+REVIEW_REQUEST_COLLECTION_TESTS = [
+    (
+        [user_review_request(PRReviewReq, name="foo")],
+        ReviewRequestSummary(requests={dummy_user(name="foo")}),
+    ),
+    (
+        [team_review_request(PRReviewReq, name="ghostty-org/spook")],
+        ReviewRequestSummary(requests={GitHubTeam(name="ghostty-org/spook")}),
+    ),
+    (
+        [
+            user_review_request(PRReviewReqRm, name="foo"),
+            team_review_request(PRReviewReqRm, name="bar"),
+        ],
+        ReviewRequestSummary(removals={dummy_user(name="foo"), GitHubTeam(name="bar")}),
+    ),
+    (
+        [
+            team_review_request(PRReviewReq, name="foo"),
+            user_review_request(PRReviewReqRm, name="bar"),
+        ],
+        ReviewRequestSummary(
+            requests={GitHubTeam(name="foo")}, removals={dummy_user(name="bar")}
+        ),
+    ),
+    (
+        [
+            team_review_request(PRReviewReq, name="foo"),
+            team_review_request(PRReviewReqRm, name="foo"),
+        ],
+        ReviewRequestSummary(accidental_requests={GitHubTeam(name="foo")}),
+    ),
+    (
+        [
+            user_review_request(PRReviewReq, name="foo"),
+            team_review_request(PRReviewReqRm, name="foo"),
+        ],
+        ReviewRequestSummary(
+            requests={dummy_user(name="foo")}, removals={GitHubTeam(name="foo")}
+        ),
+    ),
+    (
+        [
+            user_review_request(PRReviewReqRm, name="foo"),
+            user_review_request(PRReviewReq, name="foo"),
+            team_review_request(PRReviewReqRm, name="bar"),
+            team_review_request(PRReviewReq, name="baz"),
+        ],
+        ReviewRequestSummary(
+            requests={GitHubTeam(name="baz")},
+            removals={GitHubTeam(name="bar")},
+            rerequests={dummy_user(name="foo")},
+        ),
+    ),
+    (
+        [
+            user_review_request(PRReviewReqRm, name="foo"),
+            user_review_request(PRReviewReqRm, name="foo"),
+            user_review_request(PRReviewReqRm, name="foo"),
+            user_review_request(PRReviewReqRm, name="foo"),
+            user_review_request(PRReviewReqRm, name="foo"),
+            user_review_request(PRReviewReqRm, name="foo"),
+        ],
+        ReviewRequestSummary(removals={dummy_user(name="foo")}),
+    ),
+    (
+        [
+            team_review_request(PRReviewReq, name="foo"),
+            team_review_request(PRReviewReq, name="foo"),
+            team_review_request(PRReviewReq, name="foo"),
+        ],
+        ReviewRequestSummary(requests={GitHubTeam(name="foo")}),
+    ),
+    (
+        [
+            user_review_request(PRReviewReqRm, name="foo"),
+            user_review_request(PRReviewReq, name="foo"),
+            user_review_request(PRReviewReq, name="foo"),
+        ],
+        ReviewRequestSummary(rerequests={dummy_user(name="foo")}),
+    ),
+    (
+        [
+            team_review_request(PRReviewReq, name="foo"),
+            team_review_request(PRReviewReqRm, name="foo"),
+            team_review_request(PRReviewReqRm, name="foo"),
+        ],
+        ReviewRequestSummary(accidental_requests={GitHubTeam(name="foo")}),
+    ),
+    (
+        [
+            team_review_request(PRReviewReq, name="foo"),
+            team_review_request(PRReviewReqRm, name="foo"),
+            team_review_request(PRReviewReq, name="foo"),
+            team_review_request(PRReviewReqRm, name="foo"),
+            team_review_request(PRReviewReq, name="foo"),
+            team_review_request(PRReviewReqRm, name="foo"),
+            team_review_request(PRReviewReq, name="foo"),
+        ],
+        ReviewRequestSummary(requests={GitHubTeam(name="foo")}),
+    ),
+    (
+        [
+            user_review_request(PRReviewReqRm, name="foo"),
+            user_review_request(PRReviewReq, name="foo"),
+            user_review_request(PRReviewReqRm, name="foo"),
+            user_review_request(PRReviewReq, name="foo"),
+            user_review_request(PRReviewReqRm, name="foo"),
+        ],
+        ReviewRequestSummary(removals={dummy_user(name="foo")}),
+    ),
+    (
+        [
+            user_review_request(PRReviewReq, name="foo"),
+            user_review_request(PRReviewReqRm, name="foo"),
+            user_review_request(PRReviewReq, name="foo"),
+            user_review_request(PRReviewReqRm, name="foo"),
+        ],
+        ReviewRequestSummary(accidental_requests={dummy_user(name="foo")}),
+    ),
+    (
+        [
+            team_review_request(PRReviewReqRm, name="foo"),
+            team_review_request(PRReviewReq, name="foo"),
+            team_review_request(PRReviewReqRm, name="foo"),
+            team_review_request(PRReviewReq, name="foo"),
+            team_review_request(PRReviewReqRm, name="foo"),
+            team_review_request(PRReviewReq, name="foo"),
+        ],
+        ReviewRequestSummary(rerequests={GitHubTeam(name="foo")}),
+    ),
+    (
+        [
+            team_review_request(PRReviewReqRm, name="foo"),
+            team_review_request(PRReviewReq, name="foo"),
+            team_review_request(PRReviewReq, name="foo"),
+            team_review_request(PRReviewReqRm, name="foo"),
+            team_review_request(PRReviewReq, name="foo"),
+            team_review_request(PRReviewReqRm, name="foo"),
+        ],
+        ReviewRequestSummary(removals={GitHubTeam(name="foo")}),
+    ),
+    (
+        [
+            user_review_request(PRReviewReq, name="bar"),
+            user_review_request(PRReviewReqRm, name="bar"),
+            user_review_request(PRReviewReqRm, name="bar"),
+            user_review_request(PRReviewReqRm, name="bar"),
+            user_review_request(PRReviewReq, name="bar"),
+            user_review_request(PRReviewReqRm, name="bar"),
+        ],
+        ReviewRequestSummary(accidental_requests={dummy_user(name="bar")}),
+    ),
+    (
+        [
+            unknown_review_request(PRReviewReq),
+            unknown_review_request(PRReviewReq),
+            user_review_request(PRReviewReq, name="foo"),
+            unknown_review_request(PRReviewReq),
+            team_review_request(PRReviewReqRm, name="foo"),
+        ],
+        ReviewRequestSummary(
+            requests={dummy_user(name="foo")},
+            removals={GitHubTeam(name="foo")},
+            unknown_requests=3,
+        ),
+    ),
+    (
+        [
+            unknown_review_request(PRReviewReqRm),
+            unknown_review_request(PRReviewReqRm),
+            unknown_review_request(PRReviewReq),
+            user_review_request(PRReviewReqRm, name="foo"),
+            unknown_review_request(PRReviewReq),
+        ],
+        ReviewRequestSummary(
+            removals={dummy_user(name="foo")},
+            unknown_requests=2,
+            unknown_removals=2,
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("requests", "result"),
+    [([], ReviewRequestSummary()), *REVIEW_REQUEST_COLLECTION_TESTS],
+)
+async def test_collect_review_request_summary(
+    requests: list[Mock], result: ReviewRequestSummary
+) -> None:
+    assert await ReviewRequestSummary.collect(seq_to_aiter(requests)) == result
+
+
+# Since handle_review_request is just synchronization glue around
+# ReviewRequestSummary.collect, the same tests should produce the same results.
+@pytest.mark.parametrize(("requests", "result"), REVIEW_REQUEST_COLLECTION_TESTS)
+async def test_handle_review_request_collection(
+    requests: list[Mock], result: ReviewRequestSummary
+) -> None:
+    pools: ReviewPools = {}
+    await run_review_request_collection_test(pools, 12, requests, result)
+
+
+# Same as the test above, except in parallel, to catch cases where having multiple PRs
+# in the queue makes it malfunction (i.e.: bugs caused by accidental dependencies
+# between separate PRs). The other test has MUCH better error messages, so both shall be
+# run instead of only this one, despite this one being a superset of the other one.
+@settings(max_examples=10)
+@given(st.permutations(REVIEW_REQUEST_COLLECTION_TESTS))
+async def test_handle_review_request_parallel_collection(
+    tests: list[tuple[list[Mock], ReviewRequestSummary]],
+) -> None:
+    pools: ReviewPools = {}
+    async with asyncio.TaskGroup() as group:
+        for pr, (requests, result) in enumerate(tests, 1):
+            group.create_task(
+                run_review_request_collection_test(pools, pr, requests, result)
+            )
+
+
+async def run_review_request_collection_test(
+    pools: ReviewPools,
+    pr_number: int,
+    requests: list[Mock],
+    result: ReviewRequestSummary,
+) -> None:
+    first, *rest = (add_pr_metadata(m, pr_number) for m in requests)
+
+    async def enqueue() -> None:
+        for r in rest:
+            rv = await handle_review_request(pools, r, timeout=None)
+            assert rv is None
+            # Context switch unnecessarily to make sure things truly run in parallel in
+            # the parallel collection test. (Based on viewing the logs in failed cases,
+            # the scheduler does turn out to be too smart for our test without this.)
+            await asyncio.sleep(0)
+        # Explicitly shut down the queue.
+        key = ReviewPoolKey(pr_number=pr_number, actor_id=DEFAULT_PR_SENDER_ID)
+        pools.pop(key).shutdown()
+        await asyncio.sleep(0)
+
+    async with asyncio.TaskGroup() as group:
+        summary = group.create_task(handle_review_request(pools, first, timeout=None))
+        group.create_task(enqueue())
+
+    assert summary.result() == result
+
+
+@given(st.none() | st.text())
+def test_format_reviewers_empty(heading: str | None) -> None:
+    assert ReviewRequestSummary._format_reviewers(set(), 0, heading=heading) == ""
+
+
+@settings(max_examples=50)
+@given(st.sets(reviewers()), st.integers(min_value=1), st.none() | st.text())
+def test_format_reviewers_contains_reviewers(
+    reviewers: set[Reviewer], unknown: int, heading: str | None
+) -> None:
+    formatted = ReviewRequestSummary._format_reviewers(
+        reviewers, unknown, heading=heading
+    )
+    for r in reviewers:
+        assert r.format() in formatted
+
+
+@settings(max_examples=50)
+@given(st.sets(reviewers()), st.integers(min_value=1), st.none() | st.text())
+def test_format_reviewers_contains_unknown_count(
+    reviewers: set[Reviewer], unknown: int, heading: str | None
+) -> None:
+    assert f"{unknown} unknown" in ReviewRequestSummary._format_reviewers(
+        reviewers, unknown, heading=heading
+    )
+
+
+@settings(max_examples=50)
+@given(st.sets(reviewers()), st.integers(min_value=0), st.text())
+def test_format_reviewers_contains_heading(
+    reviewers: set[Reviewer], unknown: int, heading: str
+) -> None:
+    assume(reviewers or unknown)
+    assert heading in ReviewRequestSummary._format_reviewers(
+        reviewers, unknown, heading=heading
+    )
+
+
+@settings(max_examples=50)
+@given(reviewers().filter(lambda r: "\n" not in r.format()))
+def test_format_reviewers_single_reviewer_is_single_line(reviewer: Reviewer) -> None:
+    assert "\n" not in ReviewRequestSummary._format_reviewers({reviewer}, 0)
+
+
+@given(st.integers(min_value=1))
+def test_format_reviewers_unknown_only_is_single_line(unknown: int) -> None:
+    assert "\n" not in ReviewRequestSummary._format_reviewers(set(), unknown)
+
+
+@settings(max_examples=50)
+@given(
+    st.sets(reviewers().filter(lambda r: "\n" not in r.format()), min_size=2),
+    st.integers(min_value=0),
+)
+def test_format_reviewers_multiple_reviewers_on_multiple_lines(
+    reviewers: set[Reviewer], unknown: int
+) -> None:
+    assert "\n" in ReviewRequestSummary._format_reviewers(reviewers, unknown)
+
+
+@settings(max_examples=50)
+@given(
+    st.sets(reviewers().filter(lambda r: "\n" not in r.format()), min_size=1),
+    st.integers(min_value=1),
+)
+def test_format_reviewers_reviewer_and_unknown_on_multiple_lines(
+    reviewers: set[Reviewer], unknown: int
+) -> None:
+    assert "\n" in ReviewRequestSummary._format_reviewers(reviewers, unknown)
+
+
+@settings(max_examples=50)
+@given(review_request_summaries())
+def test_format_review_request_summary_has_all_reviewers(
+    s: ReviewRequestSummary,
+) -> None:
+    _, body = s.format()
+    for r in s.requests | s.removals | s.accidental_requests | s.rerequests:
+        assert r.format() in body
+    if n := s.unknown_requests:
+        assert f"{n} unknown" in body
+    if n := s.unknown_removals:
+        assert f"{n} unknown" in body
+
+
+def test_format_empty_review_request_summary() -> None:
+    assert ReviewRequestSummary().format() == ("updated review requests", "")
+
+
+@pytest.mark.parametrize(
+    ("summary", "expected_title", "expected_body"),
+    [
+        (
+            ReviewRequestSummary(requests={dummy_user(name="")}),
+            "requested review",
+            "from [``](<>)",
+        ),
+        (
+            ReviewRequestSummary(requests={GitHubTeam(name="")}),
+            "requested review",
+            "from the `` team",
+        ),
+        (
+            ReviewRequestSummary(unknown_requests=13),
+            "requested review",
+            "from 13 unknown users",
+        ),
+        (
+            ReviewRequestSummary(requests={dummy_user(name="")}, unknown_requests=23),
+            "requested review",
+            "from:\n- [``](<>)\n- 23 unknown users",
+        ),
+        (
+            ReviewRequestSummary(requests={dummy_user(name="a"), dummy_user(name="b")}),
+            "requested review",
+            "from:\n- [`a`](<>)\n- [`b`](<>)",
+        ),
+        (
+            ReviewRequestSummary(
+                requests={dummy_user(name="b"), dummy_user(name="a")},
+                unknown_requests=31,
+            ),
+            "requested review",
+            "from:\n- [`a`](<>)\n- [`b`](<>)\n- 31 unknown users",
+        ),
+        (
+            ReviewRequestSummary(
+                requests={GitHubTeam(name="b"), dummy_user(name="a")},
+                unknown_requests=6,
+            ),
+            "requested review",
+            "from:\n- [`a`](<>)\n- the `b` team\n- 6 unknown users",
+        ),
+        (
+            ReviewRequestSummary(removals={dummy_user(name="")}),
+            "removed review request",
+            "from [``](<>)",
+        ),
+        (
+            ReviewRequestSummary(removals={GitHubTeam(name="")}),
+            "removed review request",
+            "from the `` team",
+        ),
+        (
+            ReviewRequestSummary(unknown_removals=9),
+            "removed review request",
+            "from 9 unknown users",
+        ),
+        (
+            ReviewRequestSummary(removals={dummy_user(name="")}, unknown_removals=22),
+            "removed review request",
+            "from:\n- [``](<>)\n- 22 unknown users",
+        ),
+        (
+            ReviewRequestSummary(removals={dummy_user(name="a"), dummy_user(name="b")}),
+            "removed review request",
+            "from:\n- [`a`](<>)\n- [`b`](<>)",
+        ),
+        (
+            ReviewRequestSummary(
+                removals={dummy_user(name="a"), dummy_user(name="b")},
+                unknown_removals=10000,
+            ),
+            "removed review request",
+            "from:\n- [`a`](<>)\n- [`b`](<>)\n- 10000 unknown users",
+        ),
+        (
+            ReviewRequestSummary(
+                removals={dummy_user(name="a"), GitHubTeam(name="b")},
+                unknown_removals=3,
+            ),
+            "removed review request",
+            "from:\n- [`a`](<>)\n- the `b` team\n- 3 unknown users",
+        ),
+        (
+            ReviewRequestSummary(accidental_requests={dummy_user(name="")}),
+            "updated review requests",
+            "**Accidentally requested review** from [``](<>)",
+        ),
+        (
+            ReviewRequestSummary(accidental_requests={GitHubTeam(name="")}),
+            "updated review requests",
+            "**Accidentally requested review** from the `` team",
+        ),
+        (
+            ReviewRequestSummary(
+                accidental_requests={GitHubTeam(name="a"), dummy_user(name="b")}
+            ),
+            "updated review requests",
+            "**Accidentally requested review** from:\n- the `a` team\n- [`b`](<>)",
+        ),
+        (
+            ReviewRequestSummary(rerequests={dummy_user(name="")}),
+            "updated review requests",
+            "**Removed, then requested review** from [``](<>)",
+        ),
+        (
+            ReviewRequestSummary(rerequests={GitHubTeam(name="")}),
+            "updated review requests",
+            "**Removed, then requested review** from the `` team",
+        ),
+        (
+            ReviewRequestSummary(
+                rerequests={GitHubTeam(name="b"), dummy_user(name="a")}
+            ),
+            "updated review requests",
+            "**Removed, then requested review** from:\n- [`a`](<>)\n- the `b` team",
+        ),
+    ],
+)
+def test_format_review_request_summary_simple(
+    summary: ReviewRequestSummary, expected_title: str, expected_body: str
+) -> None:
+    title, body = summary.format()
+    assert title == expected_title
+    assert body == expected_body
+
+
+@pytest.mark.parametrize(
+    ("summary", "expected_body"),
+    [
+        (
+            ReviewRequestSummary(
+                requests={dummy_user(name="")},
+                accidental_requests={dummy_user(name="")},
+            ),
+            "**Requested review** from [``](<>)\n\n"
+            "**Accidentally requested review** from [``](<>)",
+        ),
+        (
+            ReviewRequestSummary(
+                accidental_requests={GitHubTeam(name="")}, unknown_requests=44
+            ),
+            "**Requested review** from 44 unknown users\n\n"
+            "**Accidentally requested review** from the `` team",
+        ),
+        (
+            ReviewRequestSummary(
+                removals={GitHubTeam(name="")},
+                accidental_requests={dummy_user(name="")},
+            ),
+            "**Removed review request** from the `` team\n\n"
+            "**Accidentally requested review** from [``](<>)",
+        ),
+        (
+            ReviewRequestSummary(
+                requests={dummy_user(name="")}, rerequests={GitHubTeam(name="")}
+            ),
+            "**Requested review** from [``](<>)\n\n"
+            "**Removed, then requested review** from the `` team",
+        ),
+        (
+            ReviewRequestSummary(
+                removals={dummy_user(name="")}, rerequests={dummy_user(name="")}
+            ),
+            "**Removed review request** from [``](<>)\n\n"
+            "**Removed, then requested review** from [``](<>)",
+        ),
+        (
+            ReviewRequestSummary(rerequests={dummy_user(name="")}, unknown_removals=17),
+            "**Removed review request** from 17 unknown users\n\n"
+            "**Removed, then requested review** from [``](<>)",
+        ),
+        (
+            ReviewRequestSummary(
+                requests={dummy_user(name="")}, removals={dummy_user(name="")}
+            ),
+            "**Requested review** from [``](<>)\n\n"
+            "**Removed review request** from [``](<>)",
+        ),
+        (
+            ReviewRequestSummary(removals={GitHubTeam(name="")}, unknown_requests=678),
+            "**Requested review** from 678 unknown users\n\n"
+            "**Removed review request** from the `` team",
+        ),
+        (
+            ReviewRequestSummary(requests={dummy_user(name="")}, unknown_removals=-3),
+            "**Requested review** from [``](<>)\n\n"
+            "**Removed review request** from -3 unknown users",
+        ),
+        (
+            ReviewRequestSummary(unknown_requests=12, unknown_removals=55),
+            "**Requested review** from 12 unknown users\n\n"
+            "**Removed review request** from 55 unknown users",
+        ),
+        (
+            ReviewRequestSummary(
+                accidental_requests={GitHubTeam(name="")},
+                rerequests={dummy_user(name="")},
+            ),
+            "**Accidentally requested review** from the `` team\n\n"
+            "**Removed, then requested review** from [``](<>)",
+        ),
+        (
+            ReviewRequestSummary(
+                requests={GitHubTeam(name="")},
+                removals={GitHubTeam(name="")},
+                accidental_requests={dummy_user(name="")},
+            ),
+            "**Requested review** from the `` team\n\n"
+            "**Removed review request** from the `` team\n\n"
+            "**Accidentally requested review** from [``](<>)",
+        ),
+        (
+            ReviewRequestSummary(
+                removals={dummy_user(name="")},
+                accidental_requests={GitHubTeam(name="")},
+                rerequests={dummy_user(name="")},
+                unknown_requests=16,
+            ),
+            "**Requested review** from 16 unknown users\n\n"
+            "**Removed review request** from [``](<>)\n\n"
+            "**Accidentally requested review** from the `` team\n\n"
+            "**Removed, then requested review** from [``](<>)",
+        ),
+        (
+            ReviewRequestSummary(
+                requests={dummy_user(name="a"), dummy_user(name="b")},
+                removals={
+                    GitHubTeam(name="b"),
+                    dummy_user(name="c"),
+                    dummy_user(name="a"),
+                },
+                rerequests={GitHubTeam(name="g")},
+                unknown_requests=13,
+                unknown_removals=4,
+            ),
+            "**Requested review** from:\n- [`a`](<>)\n- [`b`](<>)"
+            "\n- 13 unknown users\n\n"
+            "**Removed review request** from:\n- [`a`](<>)\n- the `b` team"
+            "\n- [`c`](<>)\n- 4 unknown users\n\n"
+            "**Removed, then requested review** from the `g` team",
+        ),
+        (
+            ReviewRequestSummary(
+                removals={dummy_user(name="b"), GitHubTeam(name="a")},
+                accidental_requests={GitHubTeam(name="c")},
+                unknown_requests=44,
+            ),
+            "**Requested review** from 44 unknown users\n\n"
+            "**Removed review request** from:\n- the `a` team\n- [`b`](<>)\n\n"
+            "**Accidentally requested review** from the `c` team",
+        ),
+        (
+            ReviewRequestSummary(
+                requests={
+                    GitHubTeam(name="c"),
+                    dummy_user(name="a"),
+                    GitHubTeam(name="b"),
+                },
+                removals={dummy_user(name="a"), dummy_user(name="b")},
+                accidental_requests={dummy_user(name="d"), GitHubTeam(name="e")},
+                rerequests={GitHubTeam(name="r"), GitHubTeam(name="q")},
+                unknown_requests=21,
+            ),
+            "**Requested review** from:\n- [`a`](<>)\n- the `b` team\n- the `c` team"
+            "\n- 21 unknown users\n\n"
+            "**Removed review request** from:\n- [`a`](<>)\n- [`b`](<>)\n\n"
+            "**Accidentally requested review** from:\n- [`d`](<>)\n- the `e` team\n\n"
+            "**Removed, then requested review** from:\n- the `q` team\n- the `r` team",
+        ),
+    ],
+)
+def test_format_review_request_summary_complex(
+    summary: ReviewRequestSummary, expected_body: str
+) -> None:
+    title, body = summary.format()
+    assert title == "updated review requests"
+    assert body == expected_body

--- a/tests/webhooks/utils.py
+++ b/tests/webhooks/utils.py
@@ -1,8 +1,22 @@
+from types import UnionType
+from typing import TYPE_CHECKING, get_args
 from unittest.mock import Mock
 
 from githubkit.versions.latest.models import SimpleUser
+from hypothesis import strategies as st
+from monalisten import events
 
+from app.components.github_integration.models import GitHubTeam, GitHubUser
 from app.components.github_integration.webhooks.prs import PRLike
+from app.components.github_integration.webhooks.review_summary import (
+    ReviewRequestsModified,
+    ReviewRequestSummary,
+)
+
+if TYPE_CHECKING:
+    from app.components.github_integration.webhooks.review_summary import Reviewer
+
+DEFAULT_PR_SENDER_ID = 42
 
 
 def make_user(
@@ -41,3 +55,128 @@ def make_pr(
         merged_at=merged_at,
         state=state,
     )
+
+
+@st.composite
+def github_users(draw: st.DrawFn) -> GitHubUser:
+    return GitHubUser(
+        login=draw(st.text()),
+        url=draw(st.text()),
+        icon_url=draw(st.text()),
+    )
+
+
+@st.composite
+def github_teams(draw: st.DrawFn) -> GitHubTeam:
+    return GitHubTeam(name=draw(st.text()))
+
+
+def reviewers() -> st.SearchStrategy[Reviewer]:
+    return github_teams() | github_users()
+
+
+@st.composite
+def review_request_summaries(draw: st.DrawFn) -> ReviewRequestSummary:
+    return ReviewRequestSummary(
+        requests=draw(st.sets(reviewers())),
+        removals=draw(st.sets(reviewers())),
+        accidental_requests=draw(st.sets(reviewers())),
+        rerequests=draw(st.sets(reviewers())),
+        unknown_requests=draw(st.integers(min_value=0)),
+        unknown_removals=draw(st.integers(min_value=0)),
+    )
+
+
+type MockSpec = list[str] | object | type[object] | None  # stolen from typeshed.
+
+
+def resolve_union_spec(spec: MockSpec) -> MockSpec:
+    """Return the first case of a Union, to pass isinstance tests correctly."""
+    return get_args(spec)[0] if isinstance(spec, UnionType) else spec
+
+
+def user_review_request(
+    spec: MockSpec = (), *, name: str, html_url: str = "", avatar_url: str = ""
+) -> Mock:
+    data = {"login": name, "html_url": html_url, "avatar_url": avatar_url}
+    user = Mock(SimpleUser, model_dump=Mock((), return_value=data))
+    return Mock(resolve_union_spec(spec), requested_reviewer=user)
+
+
+def team_review_request(spec: MockSpec = (), *, name: str) -> Mock:
+    team = Mock(())
+    team.name = name
+    return Mock(resolve_union_spec(spec), requested_team=team)
+
+
+def unknown_review_request(spec: MockSpec = ()) -> Mock:
+    return Mock(resolve_union_spec(spec))
+
+
+def review_requests_modifieds() -> st.SearchStrategy[type[ReviewRequestsModified]]:
+    # NOTE: using a tuple instead of a list breaks Pyright for some reason.
+    return st.sampled_from([
+        events.PullRequestReviewRequested,
+        events.PullRequestReviewRequestRemoved,
+    ])
+
+
+@st.composite
+def user_review_requests(
+    draw: st.DrawFn, *, with_pr_metadata: bool = False
+) -> ReviewRequestsModified:
+    request = user_review_request(
+        spec=draw(review_requests_modifieds()),
+        name=draw(st.text()),
+        html_url=draw(st.text()),
+        avatar_url=draw(st.text()),
+    )
+    if with_pr_metadata:
+        add_pr_metadata(request, draw(st.integers(min_value=1)))
+    return request
+
+
+@st.composite
+def team_review_requests(
+    draw: st.DrawFn, *, with_pr_metadata: bool = False
+) -> ReviewRequestsModified:
+    request = team_review_request(
+        spec=draw(review_requests_modifieds()), name=draw(st.text())
+    )
+    if with_pr_metadata:
+        add_pr_metadata(request, draw(st.integers(min_value=1)))
+    return request
+
+
+@st.composite
+def unknown_review_requests(
+    draw: st.DrawFn, *, with_pr_metadata: bool = False
+) -> ReviewRequestsModified:
+    request = unknown_review_request(spec=draw(review_requests_modifieds()))
+    if with_pr_metadata:
+        add_pr_metadata(request, draw(st.integers(min_value=1)))
+    return request
+
+
+def review_request_modification_events(
+    *,
+    with_pr_metadata: bool = False,
+    include_unknowns: bool = True,
+) -> st.SearchStrategy[ReviewRequestsModified]:
+    requests = team_review_requests(
+        with_pr_metadata=with_pr_metadata
+    ) | user_review_requests(with_pr_metadata=with_pr_metadata)
+    if include_unknowns:
+        requests = unknown_review_requests(with_pr_metadata=with_pr_metadata) | requests
+    return requests
+
+
+def dummy_user(name: str) -> GitHubUser:
+    return GitHubUser(login=name, url="", icon_url="")
+
+
+def add_pr_metadata(mock: Mock, pr_number: int) -> Mock:
+    """Mutates then returns `mock`."""
+    mock.pull_request = Mock((), number=pr_number)
+    mock.sender = Mock((), id=DEFAULT_PR_SENDER_ID)
+    return mock


### PR DESCRIPTION
Closes #509.

I unfortunately wasn't able to test this *too* well, as I couldn't get GitHub to let me request a review from someone; there are many tests though to hopefully catch everything, and I made sure sending it to Discord works fine via [`Monalisten.dispatch_event`], the code for which can be found at 3170176c3f741b5270c619bb1cdf8743e92a07dd. It is probably advisable to test it once in ghrebote with real data.

This PR isn't nearly as large as it looks; 70% of it is tests, since the logic is very intricate and is devoid of API calls.

[`Monalisten.dispatch_event`]: https://github.com/trag1c/monalisten#testing-with-manual-events