### PR TITLE
Fix review request event merging

### DIFF
--- a/app/components/github_integration/webhooks/integration.py
+++ b/app/components/github_integration/webhooks/integration.py
@@ -51,7 +51,7 @@ class GitHubWebhooks(commands.Cog):
             if (token := config().webhook.secret)
             else None,
         )
-        self._monalisten_task: asyncio.Task[None] | None = None
+        self._tasks = set[asyncio.Task[None]]()
         self._vouch_queue: VouchQueue = {}
 
     @override
@@ -59,16 +59,17 @@ class GitHubWebhooks(commands.Cog):
         register_internal_hooks(self.monalisten_client)
         discussions.register_hooks(self.monalisten_client, self._vouch_queue)
         issues.register_hooks(self.monalisten_client, self._vouch_queue)
-        prs.register_hooks(self.monalisten_client, self._vouch_queue, {})
+        prs.register_hooks(self.monalisten_client, self._tasks, self._vouch_queue, {})
         commits.register_hooks(self.monalisten_client)
 
         # Maintain strong reference to avoid task from being gc
-        self._monalisten_task = asyncio.create_task(self.monalisten_client.listen())
+        self._tasks.add(asyncio.create_task(self.monalisten_client.listen()))
 
     @override
     async def cog_unload(self) -> None:
-        if self._monalisten_task and not self._monalisten_task.done():
-            self._monalisten_task.cancel()
+        for task in self._tasks:
+            if not task.done():
+                task.cancel()
 
 
 async def setup(bot: GhosttyBot) -> None:

--- a/app/components/github_integration/webhooks/prs.py
+++ b/app/components/github_integration/webhooks/prs.py
@@ -1,5 +1,6 @@
 # pyright: reportUnusedFunction=false
 
+import asyncio
 from itertools import dropwhile
 from typing import TYPE_CHECKING, Any, Literal, Protocol, cast
 
@@ -78,6 +79,7 @@ def pr_embed_content(
 
 def register_hooks(  # noqa: C901, PLR0915
     webhook: Monalisten,
+    tasks: set[asyncio.Task[None]],
     vouch_queue: VouchQueue,
     review_pools: ReviewPools,
 ) -> None:
@@ -230,14 +232,19 @@ def register_hooks(  # noqa: C901, PLR0915
     @webhook.event.pull_request.review_requested  # pyright: ignore[reportArgumentType]
     @webhook.event.pull_request.review_request_removed
     async def review_requests_modified(event: ReviewRequestsModified) -> None:
-        pr = event.pull_request
-        if summary := await handle_review_request(review_pools, event):
-            title, body = summary.format()
-            await send_embed(
-                event.sender,
-                pr_embed_content(pr, f"{title} for {{}}", description=body),
-                pr_footer(pr),
-            )
+        async def run() -> None:
+            pr = event.pull_request
+            if summary := await handle_review_request(review_pools, event):
+                title, body = summary.format()
+                await send_embed(
+                    event.sender,
+                    pr_embed_content(pr, f"{title} for {{}}", description=body),
+                    pr_footer(pr),
+                )
+
+        task = asyncio.create_task(run())
+        tasks.add(task)
+        task.add_done_callback(tasks.discard)
 
     @webhook.event.pull_request_review.submitted
     async def submitted(event: events.PullRequestReviewSubmitted) -> None:


### PR DESCRIPTION
Follow-up to #541.

I manually tested it this time properly™ with the same dummy data as with #541; this time the code can be found at c52adec9fc76ecabda87952bec09f8ec19e7c28a.

From the commit message:
> I previously mistakenly read
https://github.com/trag1c/monalisten/blob/01e239f0d1217a940cb0c31b52727ab5b4328ac7/src/monalisten/_core.py#L180 to mean “run all hooks concurrently”, but upon closer inspection it actually simply runs all hooks *for the same event* concurrently. Currently, Monalisten runs everything synchronously w.r.t. the SSE server, which results in handle_review_request() blocking for five seconds before sending the exactly one request that was handled in that time. This change simply runs it in the background.
>
> While it might seem like Monalisten itself should be doing this for every hook, that would result in webhook events being sent out of order in some cases (though I'm not sure if this matters, since GitHub puts no effort into sending them in order anyway). More problematically, state shared between hooks, such as the vouch queue, would need to be protected, despite every current hook running fast *enough* (modulo the Discord API call) that concurrency wouldn't matter within the webhook.