### PR TITLE
webhook: reduce hunk size for `{issues,pull_request}.edited` events

### DIFF
--- a/app/components/github_integration/webhooks/prs.py
+++ b/app/components/github_integration/webhooks/prs.py
@@ -1,7 +1,6 @@
 # pyright: reportUnusedFunction=false
 
 import asyncio
-from itertools import dropwhile
 from typing import TYPE_CHECKING, Any, Literal, Protocol, cast
 
 from loguru import logger
@@ -13,6 +12,7 @@ from app.components.github_integration.webhooks.review_summary import (
 from app.components.github_integration.webhooks.utils import (
     EmbedContent,
     Footer,
+    reduce_diff_hunk,
     send_edit_difference,
     send_embed,
 )
@@ -314,7 +314,7 @@ def register_hooks(  # noqa: C901, PLR0915
             logger.info("Copilot review comment dropped")
             return
 
-        hunk = _reduce_diff_hunk(event.comment.diff_hunk)
+        hunk = reduce_diff_hunk(event.comment.diff_hunk)
         hunk_can_fit = 500 - len(content) - len(hunk) - HUNK_CODEBLOCK_OVERHEAD >= 0
         if hunk.strip() and hunk_can_fit and no_suggestions_present:
             content = HUNK_TEMPLATE.format(hunk=hunk, content=content)
@@ -329,11 +329,3 @@ def register_hooks(  # noqa: C901, PLR0915
             pr_footer(pr, from_review=True),
             origin_repo=event.repository,
         )
-
-
-def _reduce_diff_hunk(hunk: str) -> str:
-    def missing_diff_marker(line: str) -> bool:
-        return not line.startswith(("-", "+"))
-
-    hunk_lines = [*dropwhile(missing_diff_marker, hunk.splitlines())]
-    return "\n".join([*dropwhile(missing_diff_marker, hunk_lines[::-1])][::-1])

--- a/app/components/github_integration/webhooks/utils.py
+++ b/app/components/github_integration/webhooks/utils.py
@@ -3,7 +3,7 @@ import datetime as dt
 import difflib
 import re
 from functools import partial
-from itertools import islice
+from itertools import dropwhile, islice
 from typing import TYPE_CHECKING, Any, NamedTuple, NotRequired, Protocol, TypedDict
 
 import discord as dc
@@ -122,7 +122,17 @@ async def send_edit_difference(
             # If the titles are the same, there's no point in showing them;
             # they just take up a lot of the 750 available characters.
             diff_lines = islice(diff_lines, 2, None)
-        diff = truncate("\n".join(diff_lines), 750 - len("```diff\n\n```"))
+        diff = "\n".join(diff_lines)
+        max_diff_len = 750 - len("```diff\n\n```")
+        if len(diff) > max_diff_len:
+            truncated = truncate(diff, max_diff_len)
+            if not any(
+                (line.startswith("-") and not line.startswith("--- "))
+                or (line.startswith("+") and not line.startswith("+++ "))
+                for line in truncated.splitlines()
+            ):
+                diff = reduce_diff_hunk(diff)
+        diff = truncate(diff, max_diff_len)
         verb = "edited"
         content = f"```diff\n{diff}\n```"
     elif changes.title:
@@ -139,6 +149,14 @@ async def send_edit_difference(
         content_generator(event_object, f"{verb} {{}}", None, description=content),
         footer_generator(event_object),
     )
+
+
+def reduce_diff_hunk(hunk: str) -> str:
+    def missing_diff_marker(line: str) -> bool:
+        return not line.startswith(("-", "+"))
+
+    hunk_lines = [*dropwhile(missing_diff_marker, hunk.splitlines())]
+    return "\n".join([*dropwhile(missing_diff_marker, hunk_lines[::-1])][::-1])
 
 
 def _shorten_same_repo_links(

--- a/tests/webhooks/test_prs.py
+++ b/tests/webhooks/test_prs.py
@@ -6,7 +6,8 @@ import pytest
 
 from tests.webhooks.utils import make_pr
 
-from app.components.github_integration.webhooks.prs import _reduce_diff_hunk, pr_footer
+from app.components.github_integration.webhooks.prs import pr_footer
+from app.components.github_integration.webhooks.utils import reduce_diff_hunk
 
 if TYPE_CHECKING:
     from app.bot import EmojiName
@@ -45,4 +46,4 @@ def test_pr_footer(state: str, draft: bool, merged: bool, expected: EmojiName) -
     ],
 )
 def test_reduce_diff_hunk(hunk: str, expected: str) -> None:
-    assert _reduce_diff_hunk(hunk) == expected
+    assert reduce_diff_hunk(hunk) == expected


### PR DESCRIPTION
Closes #530. Not the most happy about the way it looks (both the output and the code) so *do* judge me. Take this string:
```
AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA line 1
AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA line 2
AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA line 3
the actual old line that changed
```
If a PR with this body has that last line changed, the posted message will have the long lines 1–3 excluded:
````
```diff
-the actual old line that changed
+the actual new line after edit
```
````
If line 1 isn't there, the surrounding content is small enough the hunk can fit:
````
```diff
@@ -1,3 +1,3 @@
 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA line 2
 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA line 3
-the actual old line that changed
+the actual new line after edit
```
````