### PR TITLE
Differentiate comments and entity links in webhook replacement

### DIFF
--- a/app/components/github_integration/webhooks/utils.py
+++ b/app/components/github_integration/webhooks/utils.py
@@ -34,7 +34,7 @@ GITHUB_DISCUSSION_URL = re.compile(
     r"(?P<repo>\b[a-zA-Z0-9\-\._]+)"
     r"(?P<sep>/(?:issues|pull|discussions)/)"
     r"(?P<number>\d+)"
-    r"(?:#[a-zA-Z0-9\-]+)?"
+    r"(?P<comment>#[a-zA-Z0-9\-]+)?"
 )  # fmt: skip
 
 
@@ -166,9 +166,10 @@ def _shorten_same_repo_links(
     origin_repo: RepositoryWebhooks, matchobj: re.Match[str]
 ) -> str:
     owner, _, repo = origin_repo.full_name.partition("/")
+    # Only use a short hand if the link comes from same repo
     if matchobj["owner"] == owner and matchobj["repo"] == repo:
-        # Only short hand if link comes from same repo
-        return f"[#{matchobj['number']}]({matchobj[0]})"
+        comment = " (comment)" if matchobj["comment"] else ""
+        return f"[#{matchobj['number']}{comment}]({matchobj[0]})"
     return matchobj[0]
 
 

--- a/tests/webhooks/test_utils.py
+++ b/tests/webhooks/test_utils.py
@@ -61,13 +61,13 @@ def test_footer_dict() -> None:
     [
         (
             "https://github.com/ghostty-org/ghostty/discussions/8268#discussioncomment-14492426",
-            "[#8268](https://github.com/ghostty-org/ghostty/discussions/8268#discussioncomment-14492426)",
+            "[#8268 (comment)](https://github.com/ghostty-org/ghostty/discussions/8268#discussioncomment-14492426)",
         ),
         (
-            "two months ago (https://github.com/ghostty-org/ghostty/pull/8912#issuecomm"
-            "ent-4002278186), and there",
-            "two months ago ([#8912](https://github.com/ghostty-org/ghostty/pull/8912#i"
-            "ssuecomment-4002278186)), and there",
+            "two months ago (https://github.com/ghostty-org/ghostty/pull/8912"
+            "#issuecomment-4002278186), and there",
+            "two months ago ([#8912 (comment)](https://github.com/ghostty-org/ghostty"
+            "/pull/8912#issuecomment-4002278186)), and there",
         ),
         (
             "see [#8912](https://github.com/ghostty-org/ghostty/pull/8912)",


### PR DESCRIPTION
Follow-up to #559.